### PR TITLE
PDFデータ抽出スクリプトを追加]

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ UI・体験の改善：出題ジャンルの拡充とプラットフォーム化
 ## 10. 技術スタック
 ## 10-1. 使用予定の技術
 フレームワーク：Ruby on Rails 7.2 
-DB：Neon  
+DB：Neon
 デプロイ先：Render  
 ライブラリ：line-bot-api, sidekiq-scheduler
 

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,11 +1,11 @@
-require 'line/bot'
+require "line/bot"
 
 class LineBotController < ApplicationController
-  protect_from_forgery except: [:callback]
-
+  protect_from_forgery except: [ :callback ]
+ 
   def callback
     body = request.body.read
-    signature = request.env['HTTP_X_LINE_SIGNATURE']
+    signature = request.env["HTTP_X_LINE_SIGNATURE"]
 
     begin
       events = parser.parse(body: body, signature: signature)

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -2,7 +2,7 @@ require "line/bot"
 
 class LineBotController < ApplicationController
   protect_from_forgery except: [ :callback ]
- 
+
   def callback
     body = request.body.read
     signature = request.env["HTTP_X_LINE_SIGNATURE"]

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,9 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-
+  host: db
+  username: postgres
+  password: password
 
 development:
   <<: *default

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,5 @@ Rails.application.routes.draw do
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
 
   # Defines the root path route ("/")
-  root to: proc { [200, {}, ["OK"]] }
+  root to: proc { [ 200, {}, [ "OK" ] ] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  post '/callback' => 'line_bot#callback'
+  post "/callback" => "line_bot#callback"
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,56 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.2].define(version: 2026_03_20_070221) do
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+  create_table "answers", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "question_id"
+    t.datetime "delivered_at"
+    t.boolean "is_correct"
+    t.datetime "last_answered_at"
+    t.integer "review_level"
+    t.integer "answer_choice"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "delivery_settings", force: :cascade do |t|
+    t.integer "user_id"
+    t.time "delivery_time"
+    t.string "frequency"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "questions", force: :cascade do |t|
+    t.text "content"
+    t.string "image_url"
+    t.string "choice_1"
+    t.string "choice_2"
+    t.string "choice_3"
+    t.string "choice_4"
+    t.integer "correct_answer"
+    t.string "explanation_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.string "line_user_id"
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+end

--- a/scripts/extract.py
+++ b/scripts/extract.py
@@ -1,0 +1,16 @@
+import pdfplumber
+
+def extract_text(pdf_path):
+    with pdfplumber.open(pdf_path) as pdf:
+        for i, page in enumerate(pdf.pages):
+            text = page.extract_text()
+            images = page.images
+            
+            if images:
+                text += "\n[IMAGE_HERE]\n"
+            
+            print(f"=== ページ {i+1} ===")
+            print(text)
+
+# PDFのパスを指定
+extract_text("test.pdf")

--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -1,0 +1,103 @@
+import pdfplumber
+import re
+
+def extract_answers(pdf_path):
+    answers = {}
+    with pdfplumber.open(pdf_path) as pdf:
+        for page in pdf.pages:
+            text = page.extract_text()
+            if text:
+                matches = re.findall(r'問(\d+)\s+([アイウエ])', text)
+                for num, answer in matches:
+                    answers[int(num)] = answer
+    return answers
+
+def extract_questions(pdf_path):
+    questions = []
+    with pdfplumber.open(pdf_path) as pdf:
+        full_text = ""
+        has_image_pages = set()
+
+        for i, page in enumerate(pdf.pages):
+            if i == 0:  # 1ページ目をスキップ（表紙のため不要）
+                continue
+            text = page.extract_text()
+            if text:
+                full_text += text + "\n"
+            if page.images:
+                has_image_pages.add(i)
+
+    # 問題ブロックに分割
+    blocks = re.split(r'(?=問\d+\s)', full_text)
+
+    for block in blocks:
+        block = block.strip() + '\n'
+
+        if not re.match(r'問\d+', block):
+            continue
+
+        # 問題番号を取得
+        num_match = re.match(r'問(\d+)\s+', block)
+        if not num_match:
+            continue
+        num = int(num_match.group(1))
+
+        # ① ページ番号を除去
+        block = re.sub(r'－\s*\d+\s*－', '', block)
+
+        # ② ふりがなを除去
+        RUBY_WORDS = ['ぜい']
+        pattern = '|'.join(RUBY_WORDS)
+        block = re.sub(pattern, '', block)
+
+        # ③ 選択肢ア〜エの行頭をマーキング
+        block = re.sub(r'\n([アイウエ])\s', r'\n【\1】', block)
+        # ④ 全改行を除去
+        text = re.sub(r'\n', '', block)
+        # ⑤ マーキングを改行付き選択肢に戻す
+        text = re.sub(r'【([アイウエ])】', r'\n\1 ', text)
+        # 横並び選択肢も改行（マーキング後に対応）
+        text = re.sub(r'\s([イウエ])\s', r'\n\1 ', text)
+        # ⑥ 「問X 」を除去
+        content = re.sub(r'^問\d+\s+', '', text).strip()
+        # ★テスト用（20問PDFの場合）
+        if num == 20:
+            content = re.sub(r'(\nエ [^〔©]+).*$', r'\1', content, flags=re.DOTALL).strip()
+        # 図・表・画像の目印を追加
+        if '図' in content or '表' in content or has_image_pages:
+            content += '\n[IMAGE_HERE]'
+
+        questions.append({
+            'number': num,
+            'content': content,
+        })
+
+    return questions
+
+def merge_and_export(questions, answers):
+    results = []
+    for q in questions:
+        num = q['number']
+        content = q['content']
+        has_image = '[IMAGE_HERE]' in content  # ① 先に判定
+        content = content.replace('\n[IMAGE_HERE]', '')  # ② 除去
+
+        results.append({
+            'number':         num,
+            'content':        content,
+            'correct_answer': answers.get(num, '不明'),
+            'image_url':      '[IMAGE_HERE]' if has_image else None
+        })
+    return results
+# 実行
+answers   = extract_answers('answer.pdf')
+questions = extract_questions('2018h30a_fe_am_qs.pdf')
+results   = merge_and_export(questions, answers)
+
+# 確認出力
+for r in results:
+    print(f"問{r['number']}:")
+    print(f"  content: {r['content']}") 
+    print(f"  correct_answer: {r['correct_answer']}")
+    print(f"  image_url: {r['image_url']}") 
+    print()

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
基本情報技術者試験の過去問PDFからデータを抽出するPythonスクリプトを追加

## 追加ファイル
- scripts/parse.py：問題・解答PDFからデータを抽出・整形するメイン処理
- scripts/extract.py：抽出補助スクリプト

## 処理内容
- 問題PDFから問題文・選択肢を抽出
- 解答PDFから正解を抽出