### PR TITLE
numberカラムをcreate_questionsに統合しadd_columnsマイグレーションを削除

### DIFF
--- a/db/migrate/20260320070127_create_questions.rb
+++ b/db/migrate/20260320070127_create_questions.rb
@@ -1,6 +1,7 @@
 class CreateQuestions < ActiveRecord::Migration[7.2]
   def change
     create_table :questions do |t|
+      t.integer :number
       t.text :content
       t.string :image_url
       t.string :choice_1

--- a/db/migrate/20260321120003_add_columns_to_questions.rb
+++ b/db/migrate/20260321120003_add_columns_to_questions.rb
@@ -1,5 +1,0 @@
-class AddColumnsToQuestions < ActiveRecord::Migration[7.2]
-  def change
-    add_column :questions, :number, :integer
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_03_21_120003) do
+ActiveRecord::Schema[7.2].define(version: 2026_03_20_070221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -35,6 +35,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_21_120003) do
   end
 
   create_table "questions", force: :cascade do |t|
+    t.integer "number"
     t.text "content"
     t.string "image_url"
     t.string "choice_1"
@@ -45,7 +46,6 @@ ActiveRecord::Schema[7.2].define(version: 2026_03_21_120003) do
     t.string "explanation_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "number"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
## 概要
add_columns_to_questionsマイグレーションを削除し、
numberカラムをcreate_questionsに統合

## 変更内容
- create_questionsにnumberカラムを追加
- add_columns_to_questionsマイグレーションを削除
- schema.rbを更新

## 注意
本番DBはNeon Consoleで確認済み。numberカラムは正常に存在している。