### PR TITLE
本番DB接続設定をDATABASE_URLに変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -34,12 +34,11 @@ development:
 production:
   primary: &primary_production
     <<: *default
-    database: app_production
-    username: app
+    url: <%= ENV['DATABASE_URL'] %>
     password: <%= ENV["APP_DATABASE_PASSWORD"] %>
   queue:
     <<: *primary_production
-    database: app_production
+    url: <%= ENV['DATABASE_URL'] %>
     migrations_paths: db/queue_migrate
 
   # The specified database role being used to connect to PostgreSQL.


### PR DESCRIPTION
## 概要
本番環境でのDB接続エラーを修正しました。

## 原因
database.yml の本番設定がDocker用のホスト名（db）を
参照していたため、Renderでのデプロイ時にDB接続エラーが発生していました。

## 変更内容
- `config/database.yml` の production 設定を
  `DATABASE_URL` 環境変数から接続するよう変更

## 確認事項
- [x] Render デプロイ成功
- [x] db:seed 完了
- [x] LINE Webhook 検証（200 OK）