### PR TITLE
リッチメニューIDを更新

### DIFF
--- a/lib/tasks/line_rich_menu.rake
+++ b/lib/tasks/line_rich_menu.rake
@@ -62,7 +62,7 @@ namespace :line do
   task set_default_rich_menu: :environment do
     require "net/http"
     token = ENV.fetch("LINE_CHANNEL_TOKEN")
-    rich_menu_id = "richmenu-753c165e7cadd98388909ae0ff7079cc"
+    rich_menu_id = "richmenu-070198a9129ae93d84047152dd7b9541"
 
     uri = URI("https://api.line.me/v2/bot/user/all/richmenu/#{rich_menu_id}")
     req = Net::HTTP::Post.new(uri)


### PR DESCRIPTION
## 概要
LINEリッチメニューの画像を更新し、LINE APIへの反映を確認しました。

## 変更内容
- `public/images/rich_menu.png` を新しいデザインに差し替え
- `lib/tasks/line_rich_menu.rake` の `set_default_rich_menu` タスク内のリッチメニューIDを更新

## 反映手順
本番環境にて以下のrakeタスクを実行済み：
```
docker compose exec web rails line:setup_rich_menu
```

## 動作確認
- [x] リッチメニュー作成 (200 OK)
- [x] 画像アップロード (200 OK)
- [x] デフォルト設定 (200 OK)
- [x] LINEアプリ上でリッチメニューの表示を確認

## richMenuId
`richmenu-070198a9129ae93d84047152dd7b9541`