### PR TITLE
solid_queue connects_to設定を削除（シングルDB構成に統一）

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -72,7 +72,6 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :solid_queue
-  config.solid_queue.connects_to = { database: { writing: :queue } }
   # config.active_job.queue_name_prefix = "newapp_production"
 
   # Disable caching for Action Mailer templates even if Action Controller


### PR DESCRIPTION
## 概要
Solid Queue がマルチDB構成を前提とした設定になっており、本番環境（NEON単一DB）でテーブルが作成できない問題を修正しました。

## 問題
`config/environments/production.rb` に以下の設定が残っており、存在しない `queue` データベースへの接続を試みていました。

```ruby
# 削除した設定
config.solid_queue.connects_to = { database: { writing: :queue } }
```

これにより本番環境で以下のエラーが発生していました。
```
PG::UndefinedTable: ERROR: relation "solid_queue_jobs" does not exist
```

## 修正内容

### 削除
- `config/environments/production.rb` の `solid_queue.connects_to` 設定を削除

## 技術的な意思決定

| 項目 | 採用 | 理由 |
|------|------|------|
| DB構成 | シングルDB | MVPフェーズはコストを抑えるため |
| 本番DB | NEON（PostgreSQL互換） | 無料枠で運用可能 |
| 将来の移行 | マルチDB構成も対応可能 | `database.yml` は拡張性を考慮した設計 |

## 動作確認
- [x] デプロイ成功
- [ ] `curl -X POST /api/quiz/deliver` で `{"status":"ok"}` が返る
- [ ] LINEにPush通知が届く