### PR TITLE
perform_laterをperform_nowに変更（Worker不要のMVP構成）

### DIFF
--- a/app/controllers/api/quiz_controller.rb
+++ b/app/controllers/api/quiz_controller.rb
@@ -4,7 +4,7 @@ class Api::QuizController < ApplicationController
 
   def deliver
     ScheduledPushJob.perform_now  # perform_laterからperform_nowに変更
-    render json: { status: 'ok' }
+    render json: { status: "ok" }
   end
 
   private

--- a/app/controllers/api/quiz_controller.rb
+++ b/app/controllers/api/quiz_controller.rb
@@ -3,8 +3,8 @@ class Api::QuizController < ApplicationController
   before_action :verify_cron_token
 
   def deliver
-    ScheduledPushJob.perform_later
-    render json: { status: "ok" }
+    ScheduledPushJob.perform_now  # perform_laterからperform_nowに変更
+    render json: { status: 'ok' }
   end
 
   private


### PR DESCRIPTION
## 概要
Solid Queue の Worker プロセスが起動していないため、`perform_later` でキューに積まれたジョブが実行されない問題を修正しました。MVP フェーズでは Worker を別途起動せずに動作させるため、`perform_now` に変更しました。

## 発生していた問題
```
Enqueued ScheduledPushJob to SolidQueue(default)
```
ジョブはキューに積まれるが、Worker が起動していないため実行されず LINE に通知が届かない状態でした。

## 原因
Solid Queue の Worker プロセスは別途起動が必要で、Render では追加サービスとして有料になります。MVP フェーズでは Worker を起動しない構成のため、ジョブが実行されていませんでした。

## 修正内容

### 変更
- `app/controllers/api/quiz_controller.rb`
  - `ScheduledPushJob.perform_later` → `ScheduledPushJob.perform_now` に変更
  - cron-job.org からリクエストが来た瞬間に即時実行されるように変更

## MVP → Solid Queue 移行時の対応
```ruby
# Solid Queue 導入後は1行変えるだけ
ScheduledPushJob.perform_now → ScheduledPushJob.perform_later
```

## 動作確認
- [ ] `curl -X POST /api/quiz/deliver` で `{"status":"ok"}` が返る
- [ ] LINE に Push 通知が届く
- [ ] cron-job.org で毎朝8時に自動配信される