### PR TITLE
fix: QuestionLoaderをQuestion.orderに変更

### DIFF
--- a/app/jobs/scheduled_push_job.rb
+++ b/app/jobs/scheduled_push_job.rb
@@ -10,7 +10,7 @@ class ScheduledPushJob < ApplicationJob
       channel_access_token: ENV.fetch("LINE_CHANNEL_TOKEN")
     )
 
-    q = QuestionLoader.random
+    q = Question.order("RANDOM()").first
     return Rails.logger.error "[ScheduledPushJob] 問題が見つかりません" unless q
 
     choices = {


### PR DESCRIPTION
## 概要
`ScheduledPushJob` 実行時に `QuestionLoader` が未定義のためエラーが発生していた問題を修正しました。併せて、Worker 不要の MVP 構成に対応するため `perform_later` から `perform_now` に変更しました。

## 発生していたエラー
```
NameError: uninitialized constant ScheduledPushJob::QuestionLoader
```

## 原因
`QuestionLoader` クラスが存在しないにもかかわらず、`ScheduledPushJob` 内で呼び出していました。

## 修正内容

### `app/jobs/scheduled_push_job.rb`
- `QuestionLoader.random` → `Question.order("RANDOM()").first` に変更

### `app/controllers/api/quiz_controller.rb`
- `ScheduledPushJob.perform_later` → `ScheduledPushJob.perform_now` に変更
- Worker プロセス不要の MVP 構成に対応

## MVP → Solid Queue 移行時の対応
```ruby
# Solid Queue 導入後は1行変えるだけ
ScheduledPushJob.perform_now → ScheduledPushJob.perform_later
```

## 動作確認
- [ ] `curl -X POST /api/quiz/deliver` で `{"status":"ok"}` が返る
- [ ] LINE に Push 通知が届く
- [ ] cron-job.org で毎朝 8 時に自動配信される