### PR TITLE
fix: FlexBuilderに未定義のyearキーワードを削除

### DIFF
--- a/app/jobs/scheduled_push_job.rb
+++ b/app/jobs/scheduled_push_job.rb
@@ -22,7 +22,6 @@ class ScheduledPushJob < ApplicationJob
 
     flex = FlexBuilder.question(
       question_id:   q[:number],
-      year:          q[:year],
       question_text: q[:content],
       choices:       choices,
       correct:       q[:correct_answer]


### PR DESCRIPTION
## 概要
`ScheduledPushJob` 実行時に `FlexBuilder.question` に未定義の `:year` キーワードを渡していたためエラーが発生していました。不要な `:year` を削除しました。

## 発生していたエラー
```
ArgumentError: unknown keyword: :year
```

## 原因
`FlexBuilder.question` は `:year` を受け付けていないにもかかわらず、`ScheduledPushJob` から渡していました。また、`year` カラムはアプリ内で他に使用されていないことを確認しました。

## 修正内容

### `app/jobs/scheduled_push_job.rb`
- `FlexBuilder.question` の呼び出しから `year: q[:year]` を削除

## 動作確認
- [ ] `curl -X POST /api/quiz/deliver` で `{"status":"ok"}` が返る
- [ ] LINE に Push 通知が届く
- [ ] cron-job.org で毎朝 8 時に自動配信される