### PR TITLE
Fix/cron question

### DIFF
--- a/app/jobs/scheduled_push_job.rb
+++ b/app/jobs/scheduled_push_job.rb
@@ -21,7 +21,7 @@ class ScheduledPushJob < ApplicationJob
     }
 
     flex = FlexBuilder.question(
-      question_id:   q[:number],
+      question_id:   q[:id],
       question_text: q[:content],
       choices:       choices,
       correct:       q[:correct_answer]

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -8,11 +8,12 @@
 #     command: "SoftDeletedRecord.due.delete_all"
 #     priority: 2
 #     schedule: at 5am every day
-production:
-  scheduled_push_job:
-    class: ScheduledPushJob
-    schedule: "0 23 * * *"  # 毎日朝8時JST（UTC 23:00）
-    queue: default
+
+# production:　# ←Solid Queue使用時にコメントアウト削除
+#  scheduled_push_job:
+#    class: ScheduledPushJob
+#    schedule: "0 23 * * *"  # 毎日朝8時JST（UTC 23:00）
+#    queue: default
 
 development:
   scheduled_push_job:

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,16 @@
 require 'csv'
 
-# db/csv/以下の全CSVファイルを自動で読み込む
+# r05 → "05_menjo", r06 → "06_haru" or "06_aki" など
+# CSVにexplanation_urlが入っていない場合の自動生成ルール
+YEAR_PATH = {
+  "r05" => "05_menjo",
+  # 今後追加する場合はここに追記
+  # "r06" => "06_haru",
+}.freeze
+
 Dir[Rails.root.join('db/csv/*.csv')].each do |file|
-  year = File.basename(file, '.csv')  # 例: "r05"
+  year = File.basename(file, '.csv')
+  url_path = YEAR_PATH[year] || year  # 対応表になければファイル名をそのまま使う
   Rails.logger.info "Importing #{File.basename(file)}..."
 
   CSV.foreach(file, headers: true, encoding: 'BOM|UTF-8') do |row|
@@ -16,7 +24,8 @@ Dir[Rails.root.join('db/csv/*.csv')].each do |file|
       q.choice_2        = row['choice_2']
       q.choice_3        = row['choice_3']
       q.choice_4        = row['choice_4']
-      q.explanation_url = row['explanation_url'].presence
+      q.explanation_url = row['explanation_url'].presence&.strip ||
+        "https://www.fe-siken.com/kakomon/#{url_path}/q#{number}.html"
       q.save!
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ require 'csv'
 # r05 → "05_menjo", r06 → "06_haru" or "06_aki" など
 # CSVにexplanation_urlが入っていない場合の自動生成ルール
 YEAR_PATH = {
-  "r05" => "05_menjo",
+  "r05" => "05_menjo"
   # 今後追加する場合はここに追記
   # "r06" => "06_haru",
 }.freeze

--- a/render.yaml
+++ b/render.yaml
@@ -15,20 +15,20 @@ services:
       - key: RAILS_MASTER_KEY
         sync: false
 
-  - type: cron
-    name: line-quiz-delivery
-    env: docker
-    region: singapore
-    dockerfilePath: ./Dockerfile
-    schedule: "0 15 * * *"    #0時
-    buildCommand: bundle install  # ← 追加
-    startCommand: bundle exec rails line:push_daily_question
-    envVars:
-      - key: LINE_CHANNEL_SECRET
-        sync: false
-      - key: LINE_CHANNEL_TOKEN
-        sync: false
-      - key: DATABASE_URL
-        sync: false
-      - key: RAILS_MASTER_KEY
-        sync: false
+#  - type: cron　# ← cron-job.org使用中のため無効化。cron-job.org廃止時にコメントアウト削除
+#    name: line-quiz-delivery
+#    env: docker
+#    region: singapore
+#    dockerfilePath: ./Dockerfile
+#    schedule: "0 15 * * *"    #0時
+#    buildCommand: bundle install
+#    startCommand: bundle exec rails line:push_daily_question
+#    envVars:
+#      - key: LINE_CHANNEL_SECRET
+#        sync: false
+#      - key: LINE_CHANNEL_TOKEN
+#        sync: false
+#      - key: DATABASE_URL
+#        sync: false
+#      - key: RAILS_MASTER_KEY
+#        sync: false


### PR DESCRIPTION
## 概要
cronジョブで配信された問題の解説リンクが404になるバグを修正。

## 原因
`ScheduledPushJob`で出題時に`q[:number]`をquestion_idとして送信していたが、回答のpostback処理では`Question.find_by(id: question_id)`でDBのidを使って検索していたため、レコードが見つからず`explanation_url`がnilになっていた。
その結果、フォールバックの`https://www.fe-siken.com/fe/`（404）が使われていた。

## 修正内容
- `ScheduledPushJob`の`question_id`を`q[:number]`→`q[:id]`に修正し、`handle_message`と統一

## あわせて対応
- `render.yaml`のRender cronをコメントアウト（cron-job.org使用中のため無効化）
- `config/recurring.yml`のproductionをコメントアウト（Solid Queue移行時に削除予定）

## 動作確認
- cron-job.orgのTEST RUNで200 OK確認済み
- LINEへの問題配信・解説リンク動作確認済み