### PR TITLE
解説リンク404エラーの修正

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -112,7 +112,6 @@ class LineBotController < ApplicationController
       )
 
       reply_flex(event.reply_token, flex)
-      send_next_question_push(event.source.user_id)
     end
   end
 

--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -102,6 +102,7 @@ class LineBotController < ApplicationController
       is_correct  = user_answer == correct
 
       q = Question.find_by(id: question_id)
+      Rails.logger.info "=== explanation_url: #{q&.explanation_url.inspect} ==="
 
       flex = FlexBuilder.result(
         is_correct:      is_correct,


### PR DESCRIPTION
## 問題
fe-line-bot-worker-1経由の問題回答後、解説リンクが404になる

## 原因
- 本番DBのexplanation_urlがnilになっていた
- send_next_question_pushが未定義メソッドだった

## 対応
- db:seedをビルドコマンドに追加
- 未定義メソッドの呼び出しを削除