### PR TITLE
fix: postbackのキーをquestion_idからquestion_numberに変更

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -69,7 +69,7 @@ class LineBotController < ApplicationController
       question_text = q[:content]
 
       flex = FlexBuilder.question(
-        question_id:   q[:id],
+        question_number:   q[:number],
         question_text: q[:content],
         choices:       choices,
         correct:       q[:correct_answer]
@@ -97,17 +97,16 @@ class LineBotController < ApplicationController
       reply_text(event.reply_token, "お疲れ様でした！またいつでも挑戦してね。")
     else
       user_answer = params["answer"]
-      question_id = params["question_id"].to_i
+      question_number = params["question_number"].to_i
       correct     = params["correct"]
       is_correct  = user_answer == correct
 
-      q = Question.find_by(id: question_id)
-      Rails.logger.info "=== explanation_url: #{q&.explanation_url.inspect} ==="
+      q = Question.find_by(number: question_number)
 
       flex = FlexBuilder.result(
         is_correct:      is_correct,
         correct:         correct,
-        question_id:     question_id,
+        question_id:     question_number,
         explanation_url: q&.explanation_url
       )
 

--- a/app/jobs/scheduled_push_job.rb
+++ b/app/jobs/scheduled_push_job.rb
@@ -21,7 +21,7 @@ class ScheduledPushJob < ApplicationJob
     }
 
     flex = FlexBuilder.question(
-      question_id:   q[:id],
+      question_number: q[:number],
       question_text: q[:content],
       choices:       choices,
       correct:       q[:correct_answer]

--- a/app/services/flex_builder.rb
+++ b/app/services/flex_builder.rb
@@ -1,7 +1,7 @@
 require "uri"
 
 module FlexBuilder
-  def self.question(question_id:, question_text:, choices:, correct:)
+  def self.question(question_number:, question_text:, choices:, correct:)
     rows = choices.map do |label, text|
       {
         "type"     => "box",
@@ -12,7 +12,7 @@ module FlexBuilder
           "label"       => label,
           "data"        => URI.encode_www_form([
             [ "answer", label ],
-            [ "question_id", question_id ],
+            [ "question_number", question_number ],
             [ "correct", correct ]
           ]),
           "displayText" => label
@@ -39,7 +39,7 @@ module FlexBuilder
 
     {
       "type"     => "flex",
-      "altText"  => "問#{question_id} の問題です",
+      "altText"  => "問#{question_number} の問題です",
       "contents" => {
         "type" => "bubble",
         "body" => {


### PR DESCRIPTION
## 問題
fe-line-bot-worker-1経由の問題回答後、解説リンクが404になる

## 原因
postbackのキーにquestion_id（DBのid）を使っていたが、
開発環境と本番環境でDBのidがずれていたため、
本番DBでQuestion.find_by(id: question_id)がnilを返し、
explanation_urlがnilになっていた

## 対応
postbackのキーをquestion_id→question_numberに変更し、
Question.find_by(number: question_number)で検索するように修正
idのずれに依存しない設計に変更した