### PR TITLE
 feat: 学習履歴機能の実装（基盤）

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -69,7 +69,7 @@ class LineBotController < ApplicationController
       question_text = q[:content]
 
       flex = FlexBuilder.question(
-        question_id:   q[:id],
+        question_number:   q[:number],
         question_text: q[:content],
         choices:       choices,
         correct:       q[:correct_answer]
@@ -97,17 +97,16 @@ class LineBotController < ApplicationController
       reply_text(event.reply_token, "お疲れ様でした！またいつでも挑戦してね。")
     else
       user_answer = params["answer"]
-      question_id = params["question_id"].to_i
+      question_number = params["question_number"].to_i
       correct     = params["correct"]
       is_correct  = user_answer == correct
 
-      q = Question.find_by(id: question_id)
-      Rails.logger.info "=== explanation_url: #{q&.explanation_url.inspect} ==="
+      q = Question.find_by(number: question_number)
 
       flex = FlexBuilder.result(
         is_correct:      is_correct,
         correct:         correct,
-        question_id:     question_id,
+        question_id:     question_number,
         explanation_url: q&.explanation_url
       )
 

--- a/app/jobs/scheduled_push_job.rb
+++ b/app/jobs/scheduled_push_job.rb
@@ -21,7 +21,7 @@ class ScheduledPushJob < ApplicationJob
     }
 
     flex = FlexBuilder.question(
-      question_id:   q[:id],
+      question_number: q[:number],
       question_text: q[:content],
       choices:       choices,
       correct:       q[:correct_answer]

--- a/app/services/flex_builder.rb
+++ b/app/services/flex_builder.rb
@@ -1,7 +1,7 @@
 require "uri"
 
 module FlexBuilder
-  def self.question(question_id:, question_text:, choices:, correct:)
+  def self.question(question_number:, question_text:, choices:, correct:)
     rows = choices.map do |label, text|
       {
         "type"     => "box",
@@ -12,7 +12,7 @@ module FlexBuilder
           "label"       => label,
           "data"        => URI.encode_www_form([
             [ "answer", label ],
-            [ "question_id", question_id ],
+            [ "question_number", question_number ],
             [ "correct", correct ]
           ]),
           "displayText" => label
@@ -39,7 +39,7 @@ module FlexBuilder
 
     {
       "type"     => "flex",
-      "altText"  => "問#{question_id} の問題です",
+      "altText"  => "問#{question_number} の問題です",
       "contents" => {
         "type" => "bubble",
         "body" => {


### PR DESCRIPTION
## 概要
学習履歴機能の実装に向けた基盤を整備しました。
Answerモデルの追加と、コントローラーのバグ修正により、回答データの保存が動作するようになりました。

## 変更内容

### Answerモデル追加
- `app/models/answer.rb` を作成
- `User` と `Question` への `belongs_to` アソシエーション設定
- 回答選択肢・正誤・正答率計算用カラムを追加

### 回答保存機能の実装
- postback受信時に `save_answer` で回答をAnswerテーブルに保存
- `review_level`（復習レベル）の計算ロジックを実装

### `line_bot_controller.rb` バグ修正
- `calc_review_level` のシンタックスエラー修正
- `save_answer` の typo 修正
- `handle_text` の typo 修正
- `history_message` のメソッド名・変数名修正

## 動作確認
- [x] 問題出題
- [x] 正誤判定
- [x] 回答保存（Answerテーブルへの書き込み）
- [ ] 学習履歴表示（次のPRで対応予定）