### PR TITLE
Fix/remove db seed from start command

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -48,6 +48,9 @@ class LineBotController < ApplicationController
     case text
     when "問題を解く"
       handle_message(event)
+    when "履歴", "学習履歴", "成績"
+      user = User.find_by(line_user_id: event.souece.user_id)
+      repley_text(event.reply_token, history_massage(user))
     when "設定"
       reply_text(event.reply_token, "設定機能は準備中です。")
     else
@@ -103,6 +106,10 @@ class LineBotController < ApplicationController
 
       q = Question.find_by(number: question_number)
 
+      # 回答をテーブルに保存
+      user = User.find_by(line_user_id: event.source.user_id)
+      save_answer(user, q.id, user_answer, is_correct) if user && q
+
       flex = FlexBuilder.result(
         is_correct:      is_correct,
         correct:         correct,
@@ -151,5 +158,50 @@ class LineBotController < ApplicationController
     @parser ||= Line::Bot::V2::WebhookParser.new(
       channel_secret: ENV.fetch("LINE_CHANNEL_SECRET")
     )
+  end
+
+  def save_answer(user, question_id, selected_choice, is_correct)
+    answer = Answer.find_or_initialize_by(
+      user_id: user.id,
+      question_id: question_id
+    )
+    answer.delivered_at ||= Time.current # 初回のみセット
+
+    answer.assign_attributes(
+      answer_choice:    selected_choice,
+      is_correct:       is_correct,
+      last_answered_at: Time.current,
+      review_level:     calc_review_level(answer, is_correct)
+    )
+    answer.save!
+  end
+
+  def calc_review_level(answer, is_correct)
+    current = answer.review_level.to_i
+    is_correct ? [ current + 1, 5 ].min : [ current -1, 0 ].max
+  end
+
+  def history_massage(user)
+    answers  = Answer.where(user_id: user.id).includes(:question)
+    total   = answers.count
+    correct = answers.where(is_correct: true).count
+    rate    = total.zero? ? 0 : (correct.to_f / total * 100).round(1)
+
+    recent_lines = answers.order(last_answered_at: :desc).first(5).map do |a|
+      mark = a.is_correct ? "⭕": "❌"
+      "#{mark} #{a.question.year} 問#{a.question.number}"
+    end.join("\n")
+
+    <<~TEXT
+      📊 あなたの学習履歴
+
+      回答数：#{total}問
+      正解数：#{correct}問
+      正答率：#{rate}%
+
+      ━━━━━━━━━━
+      📝 直近の回答
+      #{recent_lines.presence || "まだ回答がありません"}
+    TEXT
   end
 end

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,0 +1,4 @@
+class Answer < ApplicationRecord
+  belongs_to :user
+  belongs_to :question
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-# app/models/user.rb
 class User < ApplicationRecord
   # LINEユーザーIDでの検索・作成に使うバリデーション
   validates :line_user_id, presence: true, uniqueness: true

--- a/config/environments/index.html
+++ b/config/environments/index.html
@@ -1,9 +1,36 @@
+{
+    "destination": "Uac3b262f118636d67104eaf1f08aa1f7",
+    "events": [
+        {
+            "type": "postback",
+            "postback": {
+                "data": "answer=%E3%82%A2&question_number=9&correct=%E3%82%A8"
+            },
+            "webhookEventId": "01KR8V7JTM9ZXX1JG2JX092VPG",
+            "deliveryContext": {
+                "isRedelivery": false
+            },
+            "timestamp": 1778413455837,
+            "source": {
+                "type": "user",
+                "userId": "U8d7cfedfadd57affd87c896b4e586438"
+            },
+            "replyToken": "c89caa18514e4ee5b8fdf3ad5eb80715",
+            "mode": "active"
+        }
+    ]
+}
+500 Internal Server Error
+Summary
+Headers
+Raw
+Binary
 HTTP/1.1 500 Internal Server Error
 content-type: text/html; charset=UTF-8
-x-request-id: f60df0f6-e21c-4cdf-b4c0-70f999d6112c
-x-runtime: 0.272347
-server-timing: start_processing.action_controller;dur=0.01, process_action.action_controller;dur=14.28, render_partial.action_view;dur=6.57, render_template.action_view;dur=21.30, render_layout.action_view;dur=16.72
-content-length: 136719
+x-request-id: ef226ad4-a31d-4e09-b94e-a04dae4f3826
+x-runtime: 0.274072
+server-timing: render_partial.action_view;dur=8.15, render_template.action_view;dur=11.19, render_layout.action_view;dur=10.82
+content-length: 102459
 
 <!DOCTYPE html>
 <html lang="en">
@@ -288,19 +315,19 @@ content-length: 136719
   <!-- BEGIN /usr/local/bundle/gems/actionpack-7.2.3/lib/action_dispatch/middleware/templates/rescues/diagnostics.html.erb --><header>
   <h1>
     SyntaxError
-      in LineBotController#callback
   </h1>
 </header>
 
 <main role="main" id="container">
   <!-- BEGIN /usr/local/bundle/gems/actionpack-7.2.3/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb -->  <div class="exception-message">
-    <div class="message">/myapp/app/services/flex_builder.rb:117: syntax errors found
-<br />  115 |     }
-<br />  116 |   }
-<br />&gt; 117 | end
-<br />      |    ^ unexpected end-of-input, assuming it is closing the parent top level context
-<br />&gt; 118 | 
-<br />      | ^ expected an `end` to close the `module` statement
+    <div class="message">/myapp/app/controllers/line_bot_controller.rb:181: syntax errors found
+<br />  179 |   def calc_review_level(answer, is_corrent)
+<br />  180 |     current = answer.review_level.to_i
+<br />&gt; 181 | ... : [ current -1, 0 ].max
+<br />      |     ^ unexpected ':', ignoring it
+<br />      |     ^ unexpected ':', expecting end-of-input
+<br />  182 |   end
+<br />  183 | 
 </div>
   </div>
 <!-- END /usr/local/bundle/gems/actionpack-7.2.3/lib/action_dispatch/middleware/templates/rescues/_message_and_suggestions.html.erb -->
@@ -310,55 +337,29 @@ content-length: 136719
   <!-- BEGIN /usr/local/bundle/gems/actionpack-7.2.3/lib/action_dispatch/middleware/templates/rescues/_source.html.erb -->
     <div class="source " id="frame-source-0-0">
       <div class="info">
-        Extracted source (around line <strong>#117</strong>):
+        Extracted source (around line <strong>#181</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>115</span>
-<span>116</span>
-<span>117</span>
+<span>179</span>
+<span>180</span>
+<span>181</span>
+<span>182</span>
+<span>183</span>
+<span>184</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">    }
-</div><div class="line">  }
-</div><div class="line active">end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-7">
-      <div class="info">
-        Extracted source (around line <strong>#82</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>80</span>
-<span>81</span>
-<span>82</span>
-<span>83</span>
-<span>84</span>
-<span>85</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">          end
-</div><div class="line">        end
-</div><div class="line active">        kernel_class<span class="error_highlight">.send</span>(:no_warning_require, name)
-</div><div class="line">      end
-</div><div class="line">      if kernel_class == ::Kernel
-</div><div class="line">        kernel_class.send(:private, :require)
+<div class="line">  def calc_review_level(answer, is_corrent)
+</div><div class="line">    current = answer.review_level.to_i
+</div><div class="line active">    is correct? [ current + 1, 5 ].min : [ current -1, 0 ].max
+</div><div class="line">  end
+</div><div class="line">
+</div><div class="line">  def history_massage(user)
 </div>
 </pre>
 </td>
@@ -400,6 +401,38 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-9">
       <div class="info">
+        Extracted source (around line <strong>#82</strong>):
+      </div>
+      <div class="data">
+        <table cellpadding="0" cellspacing="0" class="lines">
+          <tr>
+            <td>
+              <pre class="line_numbers">
+<span>80</span>
+<span>81</span>
+<span>82</span>
+<span>83</span>
+<span>84</span>
+<span>85</span>
+              </pre>
+            </td>
+<td width="100%">
+<pre>
+<div class="line">          end
+</div><div class="line">        end
+</div><div class="line active">        kernel_class<span class="error_highlight">.send</span>(:no_warning_require, name)
+</div><div class="line">      end
+</div><div class="line">      if kernel_class == ::Kernel
+</div><div class="line">        kernel_class.send(:private, :require)
+</div>
+</pre>
+</td>
+          </tr>
+        </table>
+      </div>
+    </div>
+    <div class="source hidden" id="frame-source-0-10">
+      <div class="info">
         Extracted source (around line <strong>#33</strong>):
       </div>
       <div class="data">
@@ -430,7 +463,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-10">
+    <div class="source hidden" id="frame-source-0-11">
       <div class="info">
         Extracted source (around line <strong>#26</strong>):
       </div>
@@ -462,63 +495,31 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-11">
-      <div class="info">
-        Extracted source (around line <strong>#57</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>55</span>
-<span>56</span>
-<span>57</span>
-<span>58</span>
-<span>59</span>
-<span>60</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      question_text = q[:content]
-</div><div class="line">
-</div><div class="line active">      flex = <span class="error_highlight">FlexBuilder</span>.question(
-</div><div class="line">        question_id:   q[:number],
-</div><div class="line">        year:          q[:year],
-</div><div class="line">        question_text: question_text,
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
     <div class="source hidden" id="frame-source-0-12">
       <div class="info">
-        Extracted source (around line <strong>#35</strong>):
+        Extracted source (around line <strong>#290</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>33</span>
-<span>34</span>
-<span>35</span>
-<span>36</span>
-<span>37</span>
-<span>38</span>
+<span>288</span>
+<span>289</span>
+<span>290</span>
+<span>291</span>
+<span>292</span>
+<span>293</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">        case event.message
-</div><div class="line">        when Line::Bot::V2::Webhook::TextMessageContent
-</div><div class="line active">          <span class="error_highlight">handle_message</span>(event)
-</div><div class="line">        end
+<div class="line">    # unknown.
+</div><div class="line">    def constantize(camel_cased_word)
+</div><div class="line active">      Object<span class="error_highlight">.const_get</span>(camel_cased_word)
+</div><div class="line">    end
 </div><div class="line">
-</div><div class="line">      when Line::Bot::V2::Webhook::PostbackEvent
+</div><div class="line">    # Tries to find a constant with the name specified in the argument string.
 </div>
 </pre>
 </td>
@@ -528,29 +529,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-13">
       <div class="info">
-        Extracted source (around line <strong>#27</strong>):
+        Extracted source (around line <strong>#290</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>25</span>
-<span>26</span>
-<span>27</span>
-<span>28</span>
-<span>29</span>
-<span>30</span>
+<span>288</span>
+<span>289</span>
+<span>290</span>
+<span>291</span>
+<span>292</span>
+<span>293</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">    Rails.logger.info &quot;=== events: #{events.inspect}&quot;
+<div class="line">    # unknown.
+</div><div class="line">    def constantize(camel_cased_word)
+</div><div class="line active">      Object<span class="error_highlight">.const_get</span>(camel_cased_word)
+</div><div class="line">    end
 </div><div class="line">
-</div><div class="line active">    events<span class="error_highlight">.each</span> do |event|
-</div><div class="line">      case event
-</div><div class="line">      when Line::Bot::V2::Webhook::FollowEvent
-</div><div class="line">        User.find_or_create_by(line_user_id: event.source.user_id)
+</div><div class="line">    # Tries to find a constant with the name specified in the argument string.
 </div>
 </pre>
 </td>
@@ -560,29 +561,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-14">
       <div class="info">
-        Extracted source (around line <strong>#27</strong>):
+        Extracted source (around line <strong>#74</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>25</span>
-<span>26</span>
-<span>27</span>
-<span>28</span>
-<span>29</span>
-<span>30</span>
+<span>72</span>
+<span>73</span>
+<span>74</span>
+<span>75</span>
+<span>76</span>
+<span>77</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">    Rails.logger.info &quot;=== events: #{events.inspect}&quot;
+<div class="line">  # See ActiveSupport::Inflector.constantize.
+</div><div class="line">  def constantize
+</div><div class="line active">    ActiveSupport::Inflector<span class="error_highlight">.constantize</span>(self)
+</div><div class="line">  end
 </div><div class="line">
-</div><div class="line active">    events<span class="error_highlight">.each</span> do |event|
-</div><div class="line">      case event
-</div><div class="line">      when Line::Bot::V2::Webhook::FollowEvent
-</div><div class="line">        User.find_or_create_by(line_user_id: event.source.user_id)
+</div><div class="line">  # +safe_constantize+ tries to find a declared constant with the name specified
 </div>
 </pre>
 </td>
@@ -592,29 +593,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-15">
       <div class="info">
-        Extracted source (around line <strong>#8</strong>):
+        Extracted source (around line <strong>#92</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>6</span>
-<span>7</span>
-<span>8</span>
-<span>9</span>
-<span>10</span>
-<span>11</span>
+<span>90</span>
+<span>91</span>
+<span>92</span>
+<span>93</span>
+<span>94</span>
+<span>95</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">  module BasicImplicitRender # :nodoc:
-</div><div class="line">    def send_action(method, *args)
-</div><div class="line active">      ret = super
-</div><div class="line">      default_render unless performed?
-</div><div class="line">      ret
-</div><div class="line">    end
+<div class="line">        const_name = controller_param.camelize &lt;&lt; &quot;Controller&quot;
+</div><div class="line">        begin
+</div><div class="line active">          const_name<span class="error_highlight">.constantize</span>
+</div><div class="line">        rescue NameError =&gt; error
+</div><div class="line">          if error.missing_name == const_name || const_name.start_with?(&quot;#{error.missing_name}::&quot;)
+</div><div class="line">            raise MissingController.new(error.message, error.name)
 </div>
 </pre>
 </td>
@@ -624,29 +625,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-16">
       <div class="info">
-        Extracted source (around line <strong>#215</strong>):
+        Extracted source (around line <strong>#102</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>213</span>
-<span>214</span>
-<span>215</span>
-<span>216</span>
-<span>217</span>
-<span>218</span>
+<span>100</span>
+<span>101</span>
+<span>102</span>
+<span>103</span>
+<span>104</span>
+<span>105</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">      # necessarily the same as the action name.
-</div><div class="line">      def process_action(...)
-</div><div class="line active">        <span class="error_highlight">send_action</span>(...)
-</div><div class="line">      end
-</div><div class="line">
-</div><div class="line">      # Actually call the method associated with the action. Override this method if
+<div class="line">
+</div><div class="line">        def self.action_encoding_template(request, controller, action) # :nodoc:
+</div><div class="line active">          request<span class="error_highlight">.controller_class_for</span>(controller).action_encoding_template(action)
+</div><div class="line">        rescue MissingController
+</div><div class="line">          nil
+</div><div class="line">        end
 </div>
 </pre>
 </td>
@@ -656,29 +657,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-17">
       <div class="info">
-        Extracted source (around line <strong>#193</strong>):
+        Extracted source (around line <strong>#87</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>191</span>
-<span>192</span>
-<span>193</span>
-<span>194</span>
-<span>195</span>
-<span>196</span>
+<span>85</span>
+<span>86</span>
+<span>87</span>
+<span>88</span>
+<span>89</span>
+<span>90</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">      def process_action(*) # :nodoc:
-</div><div class="line">        self.formats = request.formats.filter_map(&amp;:ref)
-</div><div class="line active">        super
-</div><div class="line">      end
-</div><div class="line">
-</div><div class="line">      def _process_variant(options)
+<div class="line">      class CustomParamEncoder # :nodoc:
+</div><div class="line">        def self.encode(request, params, controller, action)
+</div><div class="line active">          return params unless controller &amp;&amp; controller.valid_encoding? &amp;&amp; encoding_template = <span class="error_highlight">action_encoding_template</span>(request, controller, action)
+</div><div class="line">          params.except(:controller, :action).each do |key, value|
+</div><div class="line">            ActionDispatch::Request::Utils.each_param_value(value) do |param|
+</div><div class="line">              # If `param` is frozen, it comes from the router defaults
 </div>
 </pre>
 </td>
@@ -688,29 +689,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-18">
       <div class="info">
-        Extracted source (around line <strong>#261</strong>):
+        Extracted source (around line <strong>#47</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>259</span>
-<span>260</span>
-<span>261</span>
-<span>262</span>
-<span>263</span>
-<span>264</span>
+<span>45</span>
+<span>46</span>
+<span>47</span>
+<span>48</span>
+<span>49</span>
+<span>50</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">      def process_action(...)
-</div><div class="line">        run_callbacks(:process_action) do
-</div><div class="line active">          super
-</div><div class="line">        end
+<div class="line">
+</div><div class="line">      def self.set_binary_encoding(request, params, controller, action)
+</div><div class="line active">        CustomParamEncoder<span class="error_highlight">.encode</span>(request, params, controller, action)
 </div><div class="line">      end
-</div><div class="line">  end
+</div><div class="line">
+</div><div class="line">      class ParamEncoder # :nodoc:
 </div>
 </pre>
 </td>
@@ -720,29 +721,29 @@ content-length: 136719
     </div>
     <div class="source hidden" id="frame-source-0-19">
       <div class="info">
-        Extracted source (around line <strong>#121</strong>):
+        Extracted source (around line <strong>#70</strong>):
       </div>
       <div class="data">
         <table cellpadding="0" cellspacing="0" class="lines">
           <tr>
             <td>
               <pre class="line_numbers">
-<span>119</span>
-<span>120</span>
-<span>121</span>
-<span>122</span>
-<span>123</span>
-<span>124</span>
+<span>68</span>
+<span>69</span>
+<span>70</span>
+<span>71</span>
+<span>72</span>
+<span>73</span>
               </pre>
             </td>
 <td width="100%">
 <pre>
-<div class="line">              current.invoke_before(env)
-</div><div class="line">              if current.final?
-</div><div class="line active">                env.value = !env.halted &amp;&amp; (!block_given? || yield)
-</div><div class="line">              elsif current.skip?(env)
-</div><div class="line">                (skipped ||= []) &lt;&lt; current
-</div><div class="line">                next_sequence = next_sequence.nested
+<div class="line">        delete_header(&quot;action_dispatch.request.parameters&quot;)
+</div><div class="line">
+</div><div class="line active">        parameters = Request::Utils<span class="error_highlight">.set_binary_encoding</span>(self, parameters, parameters[:controller], parameters[:action])
+</div><div class="line">        # If any of the path parameters has an invalid encoding then raise since it&#39;s
+</div><div class="line">        # likely to trigger errors further on.
+</div><div class="line">        Request::Utils.check_param_encoding(parameters)
 </div>
 </pre>
 </td>
@@ -751,708 +752,6 @@ content-length: 136719
       </div>
     </div>
     <div class="source hidden" id="frame-source-0-20">
-      <div class="info">
-        Extracted source (around line <strong>#24</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>22</span>
-<span>23</span>
-<span>24</span>
-<span>25</span>
-<span>26</span>
-<span>27</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">    def with_request_id(request_id)
-</div><div class="line">      old_request_id, self.current_request_id = self.current_request_id, request_id
-</div><div class="line active">      yield
-</div><div class="line">    ensure
-</div><div class="line">      self.current_request_id = old_request_id
-</div><div class="line">    end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-21">
-      <div class="info">
-        Extracted source (around line <strong>#10</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>8</span>
-<span>9</span>
-<span>10</span>
-<span>11</span>
-<span>12</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">  private
-</div><div class="line">    def turbo_tracking_request_id(&amp;block)
-</div><div class="line active">      Turbo<span class="error_highlight">.with_request_id</span>(request.headers[&quot;X-Turbo-Request-Id&quot;], &amp;block)
-</div><div class="line">    end
-</div><div class="line">end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-22">
-      <div class="info">
-        Extracted source (around line <strong>#130</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>128</span>
-<span>129</span>
-<span>130</span>
-<span>131</span>
-<span>132</span>
-<span>133</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">                begin
-</div><div class="line">                  target, block, method, *arguments = current.expand_call_template(env, invoke_sequence)
-</div><div class="line active">                  target<span class="error_highlight">.send</span>(method, *arguments, &amp;block)
-</div><div class="line">                ensure
-</div><div class="line">                  next_sequence = current
-</div><div class="line">                end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-23">
-      <div class="info">
-        Extracted source (around line <strong>#25</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>23</span>
-<span>24</span>
-<span>25</span>
-<span>26</span>
-<span>27</span>
-<span>28</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">        previous_renderer = self.renderer
-</div><div class="line">        self.renderer = renderer
-</div><div class="line active">        yield
-</div><div class="line">      ensure
-</div><div class="line">        self.renderer = previous_renderer
-</div><div class="line">      end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-24">
-      <div class="info">
-        Extracted source (around line <strong>#71</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>69</span>
-<span>70</span>
-<span>71</span>
-<span>72</span>
-<span>73</span>
-<span>74</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">        ActiveSupport.on_load(base) do
-</div><div class="line">          around_action do |controller, action|
-</div><div class="line active">            ActionText::Content<span class="error_highlight">.with_renderer</span>(controller, &amp;action)
-</div><div class="line">          end
-</div><div class="line">        end
-</div><div class="line">      end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-25">
-      <div class="info">
-        Extracted source (around line <strong>#130</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>128</span>
-<span>129</span>
-<span>130</span>
-<span>131</span>
-<span>132</span>
-<span>133</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">                begin
-</div><div class="line">                  target, block, method, *arguments = current.expand_call_template(env, invoke_sequence)
-</div><div class="line active">                  target<span class="error_highlight">.send</span>(method, *arguments, &amp;block)
-</div><div class="line">                ensure
-</div><div class="line">                  next_sequence = current
-</div><div class="line">                end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-26">
-      <div class="info">
-        Extracted source (around line <strong>#130</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>128</span>
-<span>129</span>
-<span>130</span>
-<span>131</span>
-<span>132</span>
-<span>133</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">                begin
-</div><div class="line">                  target, block, method, *arguments = current.expand_call_template(env, invoke_sequence)
-</div><div class="line active">                  target<span class="error_highlight">.send</span>(method, *arguments, &amp;block)
-</div><div class="line">                ensure
-</div><div class="line">                  next_sequence = current
-</div><div class="line">                end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-27">
-      <div class="info">
-        Extracted source (around line <strong>#141</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>139</span>
-<span>140</span>
-<span>141</span>
-<span>142</span>
-<span>143</span>
-<span>144</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">          end
-</div><div class="line">
-</div><div class="line active">          invoke_sequence<span class="error_highlight">.call</span>
-</div><div class="line">        end
-</div><div class="line">      end
-</div><div class="line">    end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-28">
-      <div class="info">
-        Extracted source (around line <strong>#260</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>258</span>
-<span>259</span>
-<span>260</span>
-<span>261</span>
-<span>262</span>
-<span>263</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      # callbacks around the normal behavior.
-</div><div class="line">      def process_action(...)
-</div><div class="line active">        <span class="error_highlight">run_callbacks</span>(:process_action) do
-</div><div class="line">          super
-</div><div class="line">        end
-</div><div class="line">      end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-29">
-      <div class="info">
-        Extracted source (around line <strong>#27</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>25</span>
-<span>26</span>
-<span>27</span>
-<span>28</span>
-<span>29</span>
-<span>30</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">    private
-</div><div class="line">      def process_action(*)
-</div><div class="line active">        super
-</div><div class="line">      rescue Exception =&gt; exception
-</div><div class="line">        request.env[&quot;action_dispatch.show_detailed_exceptions&quot;] ||= show_detailed_exceptions?
-</div><div class="line">        rescue_with_handler(exception) || raise
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-30">
-      <div class="info">
-        Extracted source (around line <strong>#77</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>75</span>
-<span>76</span>
-<span>77</span>
-<span>78</span>
-<span>79</span>
-<span>80</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">
-</div><div class="line">        ActiveSupport::Notifications.instrument(&quot;process_action.action_controller&quot;, raw_payload) do |payload|
-</div><div class="line active">          result = super
-</div><div class="line">          payload[:response] = response
-</div><div class="line">          payload[:status]   = response.status
-</div><div class="line">          result
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-31">
-      <div class="info">
-        Extracted source (around line <strong>#210</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>208</span>
-<span>209</span>
-<span>210</span>
-<span>211</span>
-<span>212</span>
-<span>213</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      def instrument(name, payload = {})
-</div><div class="line">        if notifier.listening?(name)
-</div><div class="line active">          instrumenter.instrument(name, payload) { yield payload if block_given? }
-</div><div class="line">        else
-</div><div class="line">          yield payload if block_given?
-</div><div class="line">        end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-32">
-      <div class="info">
-        Extracted source (around line <strong>#58</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>56</span>
-<span>57</span>
-<span>58</span>
-<span>59</span>
-<span>60</span>
-<span>61</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">        handle.start
-</div><div class="line">        begin
-</div><div class="line active">          yield payload if block_given?
-</div><div class="line">        rescue Exception =&gt; e
-</div><div class="line">          payload[:exception] = [e.class.name, e.message]
-</div><div class="line">          payload[:exception_object] = e
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-33">
-      <div class="info">
-        Extracted source (around line <strong>#210</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>208</span>
-<span>209</span>
-<span>210</span>
-<span>211</span>
-<span>212</span>
-<span>213</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      def instrument(name, payload = {})
-</div><div class="line">        if notifier.listening?(name)
-</div><div class="line active">          instrumenter<span class="error_highlight">.instrument</span>(name, payload) { yield payload if block_given? }
-</div><div class="line">        else
-</div><div class="line">          yield payload if block_given?
-</div><div class="line">        end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-34">
-      <div class="info">
-        Extracted source (around line <strong>#76</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>74</span>
-<span>75</span>
-<span>76</span>
-<span>77</span>
-<span>78</span>
-<span>79</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">        ActiveSupport::Notifications.instrument(&quot;start_processing.action_controller&quot;, raw_payload)
-</div><div class="line">
-</div><div class="line active">        ActiveSupport::Notifications<span class="error_highlight">.instrument</span>(&quot;process_action.action_controller&quot;, raw_payload) do |payload|
-</div><div class="line">          result = super
-</div><div class="line">          payload[:response] = response
-</div><div class="line">          payload[:status]   = response.status
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-35">
-      <div class="info">
-        Extracted source (around line <strong>#259</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>257</span>
-<span>258</span>
-<span>259</span>
-<span>260</span>
-<span>261</span>
-<span>262</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      def process_action(*)
-</div><div class="line">        _perform_parameter_wrapping if _wrapper_enabled?
-</div><div class="line active">        super
-</div><div class="line">      end
-</div><div class="line">
-</div><div class="line">      # Returns the wrapper key which will be used to store wrapped parameters.
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-36">
-      <div class="info">
-        Extracted source (around line <strong>#39</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>37</span>
-<span>38</span>
-<span>39</span>
-<span>40</span>
-<span>41</span>
-<span>42</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">          # and it won&#39;t be cleaned up by the method below.
-</div><div class="line">          ActiveRecord::RuntimeRegistry.reset
-</div><div class="line active">          super
-</div><div class="line">        end
-</div><div class="line">
-</div><div class="line">        def cleanup_view_runtime
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-37">
-      <div class="info">
-        Extracted source (around line <strong>#152</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>150</span>
-<span>151</span>
-<span>152</span>
-<span>153</span>
-<span>154</span>
-<span>155</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      @_response_body = nil
-</div><div class="line">
-</div><div class="line active">      <span class="error_highlight">process_action</span>(action_name, ...)
-</div><div class="line">    end
-</div><div class="line">
-</div><div class="line">    # Delegates to the class&#39;s ::controller_path.
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-38">
-      <div class="info">
-        Extracted source (around line <strong>#40</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>38</span>
-<span>39</span>
-<span>40</span>
-<span>41</span>
-<span>42</span>
-<span>43</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">    def process(...) # :nodoc:
-</div><div class="line">      old_config, I18n.config = I18n.config, I18nProxy.new(I18n.config, lookup_context)
-</div><div class="line active">      super
-</div><div class="line">    ensure
-</div><div class="line">      I18n.config = old_config
-</div><div class="line">    end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-39">
-      <div class="info">
-        Extracted source (around line <strong>#252</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>250</span>
-<span>251</span>
-<span>252</span>
-<span>253</span>
-<span>254</span>
-<span>255</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">      set_request!(request)
-</div><div class="line">      set_response!(response)
-</div><div class="line active">      <span class="error_highlight">process</span>(name)
-</div><div class="line">      request.commit_flash
-</div><div class="line">      to_a
-</div><div class="line">    end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-40">
-      <div class="info">
-        Extracted source (around line <strong>#335</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>333</span>
-<span>334</span>
-<span>335</span>
-<span>336</span>
-<span>337</span>
-<span>338</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">        middleware_stack.build(name) { |env| new.dispatch(name, req, res) }.call req.env
-</div><div class="line">      else
-</div><div class="line active">        new<span class="error_highlight">.dispatch</span>(name, req, res)
-</div><div class="line">      end
-</div><div class="line">    end
-</div><div class="line">  end
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-41">
-      <div class="info">
-        Extracted source (around line <strong>#67</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>65</span>
-<span>66</span>
-<span>67</span>
-<span>68</span>
-<span>69</span>
-<span>70</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">
-</div><div class="line">          def dispatch(controller, action, req, res)
-</div><div class="line active">            controller<span class="error_highlight">.dispatch</span>(action, req, res)
-</div><div class="line">          end
-</div><div class="line">      end
-</div><div class="line">
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-42">
       <div class="info">
         Extracted source (around line <strong>#50</strong>):
       </div>
@@ -1471,12 +770,12 @@ content-length: 136719
             </td>
 <td width="100%">
 <pre>
-<div class="line">          controller = controller req
-</div><div class="line">          res        = controller.make_response! req
-</div><div class="line active">          <span class="error_highlight">dispatch</span>(controller, params[:action], req, res)
-</div><div class="line">        rescue ActionController::RoutingError
-</div><div class="line">          if @raise_on_name_error
-</div><div class="line">            raise
+<div class="line">          }
+</div><div class="line">
+</div><div class="line active">          req<span class="error_highlight">.path_parameters =</span> tmp_params
+</div><div class="line">          req.route_uri_pattern = route.path.spec.to_s
+</div><div class="line">
+</div><div class="line">          _, headers, _ = response = route.app.serve(req)
 </div>
 </pre>
 </td>
@@ -1484,39 +783,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-43">
-      <div class="info">
-        Extracted source (around line <strong>#53</strong>):
-      </div>
-      <div class="data">
-        <table cellpadding="0" cellspacing="0" class="lines">
-          <tr>
-            <td>
-              <pre class="line_numbers">
-<span>51</span>
-<span>52</span>
-<span>53</span>
-<span>54</span>
-<span>55</span>
-<span>56</span>
-              </pre>
-            </td>
-<td width="100%">
-<pre>
-<div class="line">          req.route_uri_pattern = route.path.spec.to_s
-</div><div class="line">
-</div><div class="line active">          _, headers, _ = response = route.app<span class="error_highlight">.serve</span>(req)
-</div><div class="line">
-</div><div class="line">          if &quot;pass&quot; == headers[Constants::X_CASCADE]
-</div><div class="line">            req.script_name     = script_name
-</div>
-</pre>
-</td>
-          </tr>
-        </table>
-      </div>
-    </div>
-    <div class="source hidden" id="frame-source-0-44">
+    <div class="source hidden" id="frame-source-0-21">
       <div class="info">
         Extracted source (around line <strong>#133</strong>):
       </div>
@@ -1548,7 +815,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-45">
+    <div class="source hidden" id="frame-source-0-22">
       <div class="info">
         Extracted source (around line <strong>#126</strong>):
       </div>
@@ -1580,7 +847,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-46">
+    <div class="source hidden" id="frame-source-0-23">
       <div class="info">
         Extracted source (around line <strong>#126</strong>):
       </div>
@@ -1612,7 +879,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-47">
+    <div class="source hidden" id="frame-source-0-24">
       <div class="info">
         Extracted source (around line <strong>#34</strong>):
       </div>
@@ -1644,7 +911,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-48">
+    <div class="source hidden" id="frame-source-0-25">
       <div class="info">
         Extracted source (around line <strong>#896</strong>):
       </div>
@@ -1676,7 +943,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-49">
+    <div class="source hidden" id="frame-source-0-26">
       <div class="info">
         Extracted source (around line <strong>#20</strong>):
       </div>
@@ -1708,7 +975,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-50">
+    <div class="source hidden" id="frame-source-0-27">
       <div class="info">
         Extracted source (around line <strong>#29</strong>):
       </div>
@@ -1740,7 +1007,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-51">
+    <div class="source hidden" id="frame-source-0-28">
       <div class="info">
         Extracted source (around line <strong>#44</strong>):
       </div>
@@ -1772,7 +1039,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-52">
+    <div class="source hidden" id="frame-source-0-29">
       <div class="info">
         Extracted source (around line <strong>#15</strong>):
       </div>
@@ -1804,7 +1071,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-53">
+    <div class="source hidden" id="frame-source-0-30">
       <div class="info">
         Extracted source (around line <strong>#38</strong>):
       </div>
@@ -1836,7 +1103,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-54">
+    <div class="source hidden" id="frame-source-0-31">
       <div class="info">
         Extracted source (around line <strong>#38</strong>):
       </div>
@@ -1868,7 +1135,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-55">
+    <div class="source hidden" id="frame-source-0-32">
       <div class="info">
         Extracted source (around line <strong>#274</strong>):
       </div>
@@ -1900,7 +1167,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-56">
+    <div class="source hidden" id="frame-source-0-33">
       <div class="info">
         Extracted source (around line <strong>#268</strong>):
       </div>
@@ -1932,7 +1199,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-57">
+    <div class="source hidden" id="frame-source-0-34">
       <div class="info">
         Extracted source (around line <strong>#704</strong>):
       </div>
@@ -1964,7 +1231,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-58">
+    <div class="source hidden" id="frame-source-0-35">
       <div class="info">
         Extracted source (around line <strong>#674</strong>):
       </div>
@@ -1996,7 +1263,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-59">
+    <div class="source hidden" id="frame-source-0-36">
       <div class="info">
         Extracted source (around line <strong>#31</strong>):
       </div>
@@ -2028,7 +1295,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-60">
+    <div class="source hidden" id="frame-source-0-37">
       <div class="info">
         Extracted source (around line <strong>#101</strong>):
       </div>
@@ -2060,7 +1327,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-61">
+    <div class="source hidden" id="frame-source-0-38">
       <div class="info">
         Extracted source (around line <strong>#30</strong>):
       </div>
@@ -2092,7 +1359,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-62">
+    <div class="source hidden" id="frame-source-0-39">
       <div class="info">
         Extracted source (around line <strong>#16</strong>):
       </div>
@@ -2124,7 +1391,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-63">
+    <div class="source hidden" id="frame-source-0-40">
       <div class="info">
         Extracted source (around line <strong>#18</strong>):
       </div>
@@ -2156,7 +1423,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-64">
+    <div class="source hidden" id="frame-source-0-41">
       <div class="info">
         Extracted source (around line <strong>#31</strong>):
       </div>
@@ -2188,7 +1455,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-65">
+    <div class="source hidden" id="frame-source-0-42">
       <div class="info">
         Extracted source (around line <strong>#132</strong>):
       </div>
@@ -2220,7 +1487,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-66">
+    <div class="source hidden" id="frame-source-0-43">
       <div class="info">
         Extracted source (around line <strong>#19</strong>):
       </div>
@@ -2252,7 +1519,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-67">
+    <div class="source hidden" id="frame-source-0-44">
       <div class="info">
         Extracted source (around line <strong>#17</strong>):
       </div>
@@ -2284,7 +1551,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-68">
+    <div class="source hidden" id="frame-source-0-45">
       <div class="info">
         Extracted source (around line <strong>#17</strong>):
       </div>
@@ -2316,7 +1583,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-69">
+    <div class="source hidden" id="frame-source-0-46">
       <div class="info">
         Extracted source (around line <strong>#32</strong>):
       </div>
@@ -2348,7 +1615,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-70">
+    <div class="source hidden" id="frame-source-0-47">
       <div class="info">
         Extracted source (around line <strong>#41</strong>):
       </div>
@@ -2380,7 +1647,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-71">
+    <div class="source hidden" id="frame-source-0-48">
       <div class="info">
         Extracted source (around line <strong>#29</strong>):
       </div>
@@ -2412,7 +1679,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-72">
+    <div class="source hidden" id="frame-source-0-49">
       <div class="info">
         Extracted source (around line <strong>#17</strong>):
       </div>
@@ -2444,7 +1711,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-73">
+    <div class="source hidden" id="frame-source-0-50">
       <div class="info">
         Extracted source (around line <strong>#96</strong>):
       </div>
@@ -2476,7 +1743,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-74">
+    <div class="source hidden" id="frame-source-0-51">
       <div class="info">
         Extracted source (around line <strong>#33</strong>):
       </div>
@@ -2508,7 +1775,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-75">
+    <div class="source hidden" id="frame-source-0-52">
       <div class="info">
         Extracted source (around line <strong>#28</strong>):
       </div>
@@ -2540,7 +1807,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-76">
+    <div class="source hidden" id="frame-source-0-53">
       <div class="info">
         Extracted source (around line <strong>#24</strong>):
       </div>
@@ -2572,7 +1839,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-77">
+    <div class="source hidden" id="frame-source-0-54">
       <div class="info">
         Extracted source (around line <strong>#29</strong>):
       </div>
@@ -2604,7 +1871,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-78">
+    <div class="source hidden" id="frame-source-0-55">
       <div class="info">
         Extracted source (around line <strong>#61</strong>):
       </div>
@@ -2636,7 +1903,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-79">
+    <div class="source hidden" id="frame-source-0-56">
       <div class="info">
         Extracted source (around line <strong>#26</strong>):
       </div>
@@ -2668,7 +1935,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-80">
+    <div class="source hidden" id="frame-source-0-57">
       <div class="info">
         Extracted source (around line <strong>#60</strong>):
       </div>
@@ -2700,7 +1967,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-81">
+    <div class="source hidden" id="frame-source-0-58">
       <div class="info">
         Extracted source (around line <strong>#16</strong>):
       </div>
@@ -2732,7 +1999,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-82">
+    <div class="source hidden" id="frame-source-0-59">
       <div class="info">
         Extracted source (around line <strong>#27</strong>):
       </div>
@@ -2764,7 +2031,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-83">
+    <div class="source hidden" id="frame-source-0-60">
       <div class="info">
         Extracted source (around line <strong>#131</strong>):
       </div>
@@ -2796,7 +2063,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-84">
+    <div class="source hidden" id="frame-source-0-61">
       <div class="info">
         Extracted source (around line <strong>#535</strong>):
       </div>
@@ -2828,7 +2095,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-85">
+    <div class="source hidden" id="frame-source-0-62">
       <div class="info">
         Extracted source (around line <strong>#296</strong>):
       </div>
@@ -2860,7 +2127,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-86">
+    <div class="source hidden" id="frame-source-0-63">
       <div class="info">
         Extracted source (around line <strong>#103</strong>):
       </div>
@@ -2892,7 +2159,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-87">
+    <div class="source hidden" id="frame-source-0-64">
       <div class="info">
         Extracted source (around line <strong>#355</strong>):
       </div>
@@ -2924,7 +2191,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-88">
+    <div class="source hidden" id="frame-source-0-65">
       <div class="info">
         Extracted source (around line <strong>#102</strong>):
       </div>
@@ -2956,7 +2223,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-89">
+    <div class="source hidden" id="frame-source-0-66">
       <div class="info">
         Extracted source (around line <strong>#503</strong>):
       </div>
@@ -2988,7 +2255,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-90">
+    <div class="source hidden" id="frame-source-0-67">
       <div class="info">
         Extracted source (around line <strong>#262</strong>):
       </div>
@@ -3020,7 +2287,7 @@ content-length: 136719
         </table>
       </div>
     </div>
-    <div class="source hidden" id="frame-source-0-91">
+    <div class="source hidden" id="frame-source-0-68">
       <div class="info">
         Extracted source (around line <strong>#182</strong>):
       </div>
@@ -3063,375 +2330,283 @@ content-length: 136719
 
     <div id="Application-Trace-0" style="display: block;">
       <code class="traces">
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="0" href="#">
-            app/services/flex_builder.rb:117: syntax errors found
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="11" href="#">
-            app/controllers/line_bot_controller.rb:57:in &#39;LineBotController#handle_message&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="12" href="#">
-            app/controllers/line_bot_controller.rb:35:in &#39;block in LineBotController#callback&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="13" href="#">
-            app/controllers/line_bot_controller.rb:27:in &#39;Array#each&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="14" href="#">
-            app/controllers/line_bot_controller.rb:27:in &#39;LineBotController#callback&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="0" href="#">
+            app/controllers/line_bot_controller.rb:181: syntax errors found
           </a>
           <br>
       </code>
     </div>
     <div id="Framework-Trace-0" style="display: none;">
       <code class="traces">
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="1" href="#">
-              115 |     }
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="1" href="#">
+              179 |   def calc_review_level(answer, is_corrent)
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="2" href="#">
-              116 |   }
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="2" href="#">
+              180 |     current = answer.review_level.to_i
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="3" href="#">
-            &gt; 117 | end
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="3" href="#">
+            &gt; 181 | ... : [ current -1, 0 ].max
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="4" href="#">
-                  |    ^ unexpected end-of-input, assuming it is closing the parent top level context
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="4" href="#">
+                  |     ^ unexpected &#39;:&#39;, ignoring it
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="5" href="#">
-            &gt; 118 | 
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="5" href="#">
+                  |     ^ unexpected &#39;:&#39;, expecting end-of-input
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="6" href="#">
-                  | ^ expected an `end` to close the `module` statement
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="6" href="#">
+              182 |   end
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="7" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="7" href="#">
+              183 | 
+          </a>
+          <br>
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="8" href="#">
             /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in &#39;Kernel.require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="8" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="9" href="#">
             /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in &#39;block (2 levels) in Kernel#replace_require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="9" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="10" href="#">
             bootsnap (1.23.0) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in &#39;Kernel#require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="10" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="11" href="#">
             zeitwerk (2.7.5) lib/zeitwerk/core_ext/kernel.rb:26:in &#39;Kernel#require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="15" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/basic_implicit_render.rb:8:in &#39;ActionController::BasicImplicitRender#send_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="12" href="#">
+            activesupport (7.2.3) lib/active_support/inflector/methods.rb:290:in &#39;Module#const_get&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="16" href="#">
-            actionpack (7.2.3) lib/abstract_controller/base.rb:215:in &#39;AbstractController::Base#process_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="13" href="#">
+            activesupport (7.2.3) lib/active_support/inflector/methods.rb:290:in &#39;ActiveSupport::Inflector#constantize&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="17" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/rendering.rb:193:in &#39;ActionController::Rendering#process_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="14" href="#">
+            activesupport (7.2.3) lib/active_support/core_ext/string/inflections.rb:74:in &#39;String#constantize&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="18" href="#">
-            actionpack (7.2.3) lib/abstract_controller/callbacks.rb:261:in &#39;block in AbstractController::Callbacks#process_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="15" href="#">
+            actionpack (7.2.3) lib/action_dispatch/http/request.rb:92:in &#39;ActionDispatch::Request#controller_class_for&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="19" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:121:in &#39;block in ActiveSupport::Callbacks#run_callbacks&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="16" href="#">
+            actionpack (7.2.3) lib/action_dispatch/request/utils.rb:102:in &#39;ActionDispatch::Request::Utils::CustomParamEncoder.action_encoding_template&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="20" href="#">
-            turbo-rails (2.0.23) lib/turbo-rails.rb:24:in &#39;Turbo.with_request_id&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="17" href="#">
+            actionpack (7.2.3) lib/action_dispatch/request/utils.rb:87:in &#39;ActionDispatch::Request::Utils::CustomParamEncoder.encode&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="21" href="#">
-            turbo-rails (2.0.23) app/controllers/concerns/turbo/request_id_tracking.rb:10:in &#39;Turbo::RequestIdTracking#turbo_tracking_request_id&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="18" href="#">
+            actionpack (7.2.3) lib/action_dispatch/request/utils.rb:47:in &#39;ActionDispatch::Request::Utils.set_binary_encoding&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="22" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:130:in &#39;block in ActiveSupport::Callbacks#run_callbacks&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="19" href="#">
+            actionpack (7.2.3) lib/action_dispatch/http/parameters.rb:70:in &#39;ActionDispatch::Http::Parameters#path_parameters=&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="23" href="#">
-            actiontext (7.2.3) lib/action_text/rendering.rb:25:in &#39;ActionText::Rendering::ClassMethods#with_renderer&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="20" href="#">
+            actionpack (7.2.3) lib/action_dispatch/journey/router.rb:50:in &#39;block in ActionDispatch::Journey::Router#serve&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="24" href="#">
-            actiontext (7.2.3) lib/action_text/engine.rb:71:in &#39;block (4 levels) in &lt;class:Engine&gt;&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="25" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:130:in &#39;BasicObject#instance_exec&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="26" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:130:in &#39;block in ActiveSupport::Callbacks#run_callbacks&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="27" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:141:in &#39;ActiveSupport::Callbacks#run_callbacks&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="28" href="#">
-            actionpack (7.2.3) lib/abstract_controller/callbacks.rb:260:in &#39;AbstractController::Callbacks#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="29" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/rescue.rb:27:in &#39;ActionController::Rescue#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="30" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/instrumentation.rb:77:in &#39;block in ActionController::Instrumentation#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="31" href="#">
-            activesupport (7.2.3) lib/active_support/notifications.rb:210:in &#39;block in ActiveSupport::Notifications.instrument&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="32" href="#">
-            activesupport (7.2.3) lib/active_support/notifications/instrumenter.rb:58:in &#39;ActiveSupport::Notifications::Instrumenter#instrument&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="33" href="#">
-            activesupport (7.2.3) lib/active_support/notifications.rb:210:in &#39;ActiveSupport::Notifications.instrument&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="34" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/instrumentation.rb:76:in &#39;ActionController::Instrumentation#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="35" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/params_wrapper.rb:259:in &#39;ActionController::ParamsWrapper#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="36" href="#">
-            activerecord (7.2.3) lib/active_record/railties/controller_runtime.rb:39:in &#39;ActiveRecord::Railties::ControllerRuntime#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="37" href="#">
-            actionpack (7.2.3) lib/abstract_controller/base.rb:152:in &#39;AbstractController::Base#process&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="38" href="#">
-            actionview (7.2.3) lib/action_view/rendering.rb:40:in &#39;ActionView::Rendering#process&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="39" href="#">
-            actionpack (7.2.3) lib/action_controller/metal.rb:252:in &#39;ActionController::Metal#dispatch&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="40" href="#">
-            actionpack (7.2.3) lib/action_controller/metal.rb:335:in &#39;ActionController::Metal.dispatch&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="41" href="#">
-            actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:67:in &#39;ActionDispatch::Routing::RouteSet::Dispatcher#dispatch&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="42" href="#">
-            actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:50:in &#39;ActionDispatch::Routing::RouteSet::Dispatcher#serve&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="43" href="#">
-            actionpack (7.2.3) lib/action_dispatch/journey/router.rb:53:in &#39;block in ActionDispatch::Journey::Router#serve&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="44" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="21" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:133:in &#39;block in ActionDispatch::Journey::Router#find_routes&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="45" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="22" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:126:in &#39;Array#each&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="46" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="23" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:126:in &#39;ActionDispatch::Journey::Router#find_routes&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="47" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="24" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:34:in &#39;ActionDispatch::Journey::Router#serve&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="48" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="25" href="#">
             actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:896:in &#39;ActionDispatch::Routing::RouteSet#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="49" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="26" href="#">
             rack (3.2.5) lib/rack/tempfile_reaper.rb:20:in &#39;Rack::TempfileReaper#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="50" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="27" href="#">
             rack (3.2.5) lib/rack/etag.rb:29:in &#39;Rack::ETag#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="51" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="28" href="#">
             rack (3.2.5) lib/rack/conditional_get.rb:44:in &#39;Rack::ConditionalGet#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="52" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="29" href="#">
             rack (3.2.5) lib/rack/head.rb:15:in &#39;Rack::Head#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="53" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="30" href="#">
             actionpack (7.2.3) lib/action_dispatch/http/permissions_policy.rb:38:in &#39;ActionDispatch::PermissionsPolicy::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="54" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="31" href="#">
             actionpack (7.2.3) lib/action_dispatch/http/content_security_policy.rb:38:in &#39;ActionDispatch::ContentSecurityPolicy::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="55" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="32" href="#">
             rack-session (2.1.1) lib/rack/session/abstract/id.rb:274:in &#39;Rack::Session::Abstract::Persisted#context&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="56" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="33" href="#">
             rack-session (2.1.1) lib/rack/session/abstract/id.rb:268:in &#39;Rack::Session::Abstract::Persisted#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="57" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="34" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/cookies.rb:704:in &#39;ActionDispatch::Cookies#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="58" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="35" href="#">
             activerecord (7.2.3) lib/active_record/migration.rb:674:in &#39;ActiveRecord::Migration::CheckPending#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="59" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="36" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/callbacks.rb:31:in &#39;block in ActionDispatch::Callbacks#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="60" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="37" href="#">
             activesupport (7.2.3) lib/active_support/callbacks.rb:101:in &#39;ActiveSupport::Callbacks#run_callbacks&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="61" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="38" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/callbacks.rb:30:in &#39;ActionDispatch::Callbacks#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="62" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="39" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/executor.rb:16:in &#39;ActionDispatch::Executor#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="63" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="40" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in &#39;ActionDispatch::ActionableExceptions#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="64" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="41" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/debug_exceptions.rb:31:in &#39;ActionDispatch::DebugExceptions#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="65" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="42" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:132:in &#39;WebConsole::Middleware#call_app&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="66" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="43" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:19:in &#39;block in WebConsole::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="67" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="44" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:17:in &#39;Kernel#catch&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="68" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="45" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:17:in &#39;WebConsole::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="69" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="46" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/show_exceptions.rb:32:in &#39;ActionDispatch::ShowExceptions#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="70" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="47" href="#">
             railties (7.2.3) lib/rails/rack/logger.rb:41:in &#39;Rails::Rack::Logger#call_app&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="71" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="48" href="#">
             railties (7.2.3) lib/rails/rack/logger.rb:29:in &#39;Rails::Rack::Logger#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="72" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="49" href="#">
             sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in &#39;Sprockets::Rails::QuietAssets#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="73" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="50" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/remote_ip.rb:96:in &#39;ActionDispatch::RemoteIp#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="74" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="51" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/request_id.rb:33:in &#39;ActionDispatch::RequestId#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="75" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="52" href="#">
             rack (3.2.5) lib/rack/method_override.rb:28:in &#39;Rack::MethodOverride#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="76" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="53" href="#">
             rack (3.2.5) lib/rack/runtime.rb:24:in &#39;Rack::Runtime#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="77" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="54" href="#">
             activesupport (7.2.3) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in &#39;ActiveSupport::Cache::Strategy::LocalCache::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="78" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="55" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/server_timing.rb:61:in &#39;block in ActionDispatch::ServerTiming#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="79" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="56" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/server_timing.rb:26:in &#39;ActionDispatch::ServerTiming::Subscriber#collect_events&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="80" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="57" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/server_timing.rb:60:in &#39;ActionDispatch::ServerTiming#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="81" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="58" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/executor.rb:16:in &#39;ActionDispatch::Executor#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="82" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="59" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/static.rb:27:in &#39;ActionDispatch::Static#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="83" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="60" href="#">
             rack (3.2.5) lib/rack/sendfile.rb:131:in &#39;Rack::Sendfile#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="84" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="61" href="#">
             railties (7.2.3) lib/rails/engine.rb:535:in &#39;Rails::Engine#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="85" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="62" href="#">
             puma (7.2.0) lib/puma/configuration.rb:296:in &#39;Puma::Configuration::ConfigMiddleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="86" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="63" href="#">
             puma (7.2.0) lib/puma/request.rb:103:in &#39;block in Puma::Request#handle_request&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="87" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="64" href="#">
             puma (7.2.0) lib/puma/thread_pool.rb:355:in &#39;Puma::ThreadPool#with_force_shutdown&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="88" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="65" href="#">
             puma (7.2.0) lib/puma/request.rb:102:in &#39;Puma::Request#handle_request&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="89" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="66" href="#">
             puma (7.2.0) lib/puma/server.rb:503:in &#39;Puma::Server#process_client&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="90" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="67" href="#">
             puma (7.2.0) lib/puma/server.rb:262:in &#39;block in Puma::Server#run&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="91" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="68" href="#">
             puma (7.2.0) lib/puma/thread_pool.rb:182:in &#39;block in Puma::ThreadPool#spawn_thread&#39;
           </a>
           <br>
@@ -3439,371 +2614,279 @@ content-length: 136719
     </div>
     <div id="Full-Trace-0" style="display: none;">
       <code class="traces">
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="0" href="#">
-            app/services/flex_builder.rb:117: syntax errors found
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="0" href="#">
+            app/controllers/line_bot_controller.rb:181: syntax errors found
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="1" href="#">
-              115 |     }
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="1" href="#">
+              179 |   def calc_review_level(answer, is_corrent)
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="2" href="#">
-              116 |   }
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="2" href="#">
+              180 |     current = answer.review_level.to_i
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="3" href="#">
-            &gt; 117 | end
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="3" href="#">
+            &gt; 181 | ... : [ current -1, 0 ].max
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="4" href="#">
-                  |    ^ unexpected end-of-input, assuming it is closing the parent top level context
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="4" href="#">
+                  |     ^ unexpected &#39;:&#39;, ignoring it
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="5" href="#">
-            &gt; 118 | 
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="5" href="#">
+                  |     ^ unexpected &#39;:&#39;, expecting end-of-input
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="6" href="#">
-                  | ^ expected an `end` to close the `module` statement
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="6" href="#">
+              182 |   end
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="7" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="7" href="#">
+              183 | 
+          </a>
+          <br>
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="8" href="#">
             /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in &#39;Kernel.require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="8" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="9" href="#">
             /usr/local/lib/ruby/3.4.0/bundled_gems.rb:82:in &#39;block (2 levels) in Kernel#replace_require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="9" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="10" href="#">
             bootsnap (1.23.0) lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in &#39;Kernel#require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="10" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="11" href="#">
             zeitwerk (2.7.5) lib/zeitwerk/core_ext/kernel.rb:26:in &#39;Kernel#require&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="11" href="#">
-            app/controllers/line_bot_controller.rb:57:in &#39;LineBotController#handle_message&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="12" href="#">
+            activesupport (7.2.3) lib/active_support/inflector/methods.rb:290:in &#39;Module#const_get&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="12" href="#">
-            app/controllers/line_bot_controller.rb:35:in &#39;block in LineBotController#callback&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="13" href="#">
+            activesupport (7.2.3) lib/active_support/inflector/methods.rb:290:in &#39;ActiveSupport::Inflector#constantize&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="13" href="#">
-            app/controllers/line_bot_controller.rb:27:in &#39;Array#each&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="14" href="#">
+            activesupport (7.2.3) lib/active_support/core_ext/string/inflections.rb:74:in &#39;String#constantize&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="14" href="#">
-            app/controllers/line_bot_controller.rb:27:in &#39;LineBotController#callback&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="15" href="#">
+            actionpack (7.2.3) lib/action_dispatch/http/request.rb:92:in &#39;ActionDispatch::Request#controller_class_for&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="15" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/basic_implicit_render.rb:8:in &#39;ActionController::BasicImplicitRender#send_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="16" href="#">
+            actionpack (7.2.3) lib/action_dispatch/request/utils.rb:102:in &#39;ActionDispatch::Request::Utils::CustomParamEncoder.action_encoding_template&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="16" href="#">
-            actionpack (7.2.3) lib/abstract_controller/base.rb:215:in &#39;AbstractController::Base#process_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="17" href="#">
+            actionpack (7.2.3) lib/action_dispatch/request/utils.rb:87:in &#39;ActionDispatch::Request::Utils::CustomParamEncoder.encode&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="17" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/rendering.rb:193:in &#39;ActionController::Rendering#process_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="18" href="#">
+            actionpack (7.2.3) lib/action_dispatch/request/utils.rb:47:in &#39;ActionDispatch::Request::Utils.set_binary_encoding&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="18" href="#">
-            actionpack (7.2.3) lib/abstract_controller/callbacks.rb:261:in &#39;block in AbstractController::Callbacks#process_action&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="19" href="#">
+            actionpack (7.2.3) lib/action_dispatch/http/parameters.rb:70:in &#39;ActionDispatch::Http::Parameters#path_parameters=&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="19" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:121:in &#39;block in ActiveSupport::Callbacks#run_callbacks&#39;
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="20" href="#">
+            actionpack (7.2.3) lib/action_dispatch/journey/router.rb:50:in &#39;block in ActionDispatch::Journey::Router#serve&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="20" href="#">
-            turbo-rails (2.0.23) lib/turbo-rails.rb:24:in &#39;Turbo.with_request_id&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="21" href="#">
-            turbo-rails (2.0.23) app/controllers/concerns/turbo/request_id_tracking.rb:10:in &#39;Turbo::RequestIdTracking#turbo_tracking_request_id&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="22" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:130:in &#39;block in ActiveSupport::Callbacks#run_callbacks&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="23" href="#">
-            actiontext (7.2.3) lib/action_text/rendering.rb:25:in &#39;ActionText::Rendering::ClassMethods#with_renderer&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="24" href="#">
-            actiontext (7.2.3) lib/action_text/engine.rb:71:in &#39;block (4 levels) in &lt;class:Engine&gt;&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="25" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:130:in &#39;BasicObject#instance_exec&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="26" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:130:in &#39;block in ActiveSupport::Callbacks#run_callbacks&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="27" href="#">
-            activesupport (7.2.3) lib/active_support/callbacks.rb:141:in &#39;ActiveSupport::Callbacks#run_callbacks&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="28" href="#">
-            actionpack (7.2.3) lib/abstract_controller/callbacks.rb:260:in &#39;AbstractController::Callbacks#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="29" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/rescue.rb:27:in &#39;ActionController::Rescue#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="30" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/instrumentation.rb:77:in &#39;block in ActionController::Instrumentation#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="31" href="#">
-            activesupport (7.2.3) lib/active_support/notifications.rb:210:in &#39;block in ActiveSupport::Notifications.instrument&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="32" href="#">
-            activesupport (7.2.3) lib/active_support/notifications/instrumenter.rb:58:in &#39;ActiveSupport::Notifications::Instrumenter#instrument&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="33" href="#">
-            activesupport (7.2.3) lib/active_support/notifications.rb:210:in &#39;ActiveSupport::Notifications.instrument&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="34" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/instrumentation.rb:76:in &#39;ActionController::Instrumentation#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="35" href="#">
-            actionpack (7.2.3) lib/action_controller/metal/params_wrapper.rb:259:in &#39;ActionController::ParamsWrapper#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="36" href="#">
-            activerecord (7.2.3) lib/active_record/railties/controller_runtime.rb:39:in &#39;ActiveRecord::Railties::ControllerRuntime#process_action&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="37" href="#">
-            actionpack (7.2.3) lib/abstract_controller/base.rb:152:in &#39;AbstractController::Base#process&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="38" href="#">
-            actionview (7.2.3) lib/action_view/rendering.rb:40:in &#39;ActionView::Rendering#process&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="39" href="#">
-            actionpack (7.2.3) lib/action_controller/metal.rb:252:in &#39;ActionController::Metal#dispatch&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="40" href="#">
-            actionpack (7.2.3) lib/action_controller/metal.rb:335:in &#39;ActionController::Metal.dispatch&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="41" href="#">
-            actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:67:in &#39;ActionDispatch::Routing::RouteSet::Dispatcher#dispatch&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="42" href="#">
-            actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:50:in &#39;ActionDispatch::Routing::RouteSet::Dispatcher#serve&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="43" href="#">
-            actionpack (7.2.3) lib/action_dispatch/journey/router.rb:53:in &#39;block in ActionDispatch::Journey::Router#serve&#39;
-          </a>
-          <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="44" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="21" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:133:in &#39;block in ActionDispatch::Journey::Router#find_routes&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="45" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="22" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:126:in &#39;Array#each&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="46" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="23" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:126:in &#39;ActionDispatch::Journey::Router#find_routes&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="47" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="24" href="#">
             actionpack (7.2.3) lib/action_dispatch/journey/router.rb:34:in &#39;ActionDispatch::Journey::Router#serve&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="48" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="25" href="#">
             actionpack (7.2.3) lib/action_dispatch/routing/route_set.rb:896:in &#39;ActionDispatch::Routing::RouteSet#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="49" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="26" href="#">
             rack (3.2.5) lib/rack/tempfile_reaper.rb:20:in &#39;Rack::TempfileReaper#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="50" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="27" href="#">
             rack (3.2.5) lib/rack/etag.rb:29:in &#39;Rack::ETag#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="51" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="28" href="#">
             rack (3.2.5) lib/rack/conditional_get.rb:44:in &#39;Rack::ConditionalGet#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="52" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="29" href="#">
             rack (3.2.5) lib/rack/head.rb:15:in &#39;Rack::Head#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="53" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="30" href="#">
             actionpack (7.2.3) lib/action_dispatch/http/permissions_policy.rb:38:in &#39;ActionDispatch::PermissionsPolicy::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="54" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="31" href="#">
             actionpack (7.2.3) lib/action_dispatch/http/content_security_policy.rb:38:in &#39;ActionDispatch::ContentSecurityPolicy::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="55" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="32" href="#">
             rack-session (2.1.1) lib/rack/session/abstract/id.rb:274:in &#39;Rack::Session::Abstract::Persisted#context&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="56" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="33" href="#">
             rack-session (2.1.1) lib/rack/session/abstract/id.rb:268:in &#39;Rack::Session::Abstract::Persisted#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="57" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="34" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/cookies.rb:704:in &#39;ActionDispatch::Cookies#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="58" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="35" href="#">
             activerecord (7.2.3) lib/active_record/migration.rb:674:in &#39;ActiveRecord::Migration::CheckPending#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="59" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="36" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/callbacks.rb:31:in &#39;block in ActionDispatch::Callbacks#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="60" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="37" href="#">
             activesupport (7.2.3) lib/active_support/callbacks.rb:101:in &#39;ActiveSupport::Callbacks#run_callbacks&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="61" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="38" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/callbacks.rb:30:in &#39;ActionDispatch::Callbacks#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="62" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="39" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/executor.rb:16:in &#39;ActionDispatch::Executor#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="63" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="40" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/actionable_exceptions.rb:18:in &#39;ActionDispatch::ActionableExceptions#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="64" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="41" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/debug_exceptions.rb:31:in &#39;ActionDispatch::DebugExceptions#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="65" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="42" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:132:in &#39;WebConsole::Middleware#call_app&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="66" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="43" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:19:in &#39;block in WebConsole::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="67" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="44" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:17:in &#39;Kernel#catch&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="68" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="45" href="#">
             web-console (4.2.1) lib/web_console/middleware.rb:17:in &#39;WebConsole::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="69" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="46" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/show_exceptions.rb:32:in &#39;ActionDispatch::ShowExceptions#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="70" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="47" href="#">
             railties (7.2.3) lib/rails/rack/logger.rb:41:in &#39;Rails::Rack::Logger#call_app&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="71" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="48" href="#">
             railties (7.2.3) lib/rails/rack/logger.rb:29:in &#39;Rails::Rack::Logger#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="72" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="49" href="#">
             sprockets-rails (3.5.2) lib/sprockets/rails/quiet_assets.rb:17:in &#39;Sprockets::Rails::QuietAssets#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="73" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="50" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/remote_ip.rb:96:in &#39;ActionDispatch::RemoteIp#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="74" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="51" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/request_id.rb:33:in &#39;ActionDispatch::RequestId#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="75" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="52" href="#">
             rack (3.2.5) lib/rack/method_override.rb:28:in &#39;Rack::MethodOverride#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="76" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="53" href="#">
             rack (3.2.5) lib/rack/runtime.rb:24:in &#39;Rack::Runtime#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="77" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="54" href="#">
             activesupport (7.2.3) lib/active_support/cache/strategy/local_cache_middleware.rb:29:in &#39;ActiveSupport::Cache::Strategy::LocalCache::Middleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="78" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="55" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/server_timing.rb:61:in &#39;block in ActionDispatch::ServerTiming#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="79" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="56" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/server_timing.rb:26:in &#39;ActionDispatch::ServerTiming::Subscriber#collect_events&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="80" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="57" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/server_timing.rb:60:in &#39;ActionDispatch::ServerTiming#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="81" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="58" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/executor.rb:16:in &#39;ActionDispatch::Executor#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="82" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="59" href="#">
             actionpack (7.2.3) lib/action_dispatch/middleware/static.rb:27:in &#39;ActionDispatch::Static#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="83" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="60" href="#">
             rack (3.2.5) lib/rack/sendfile.rb:131:in &#39;Rack::Sendfile#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="84" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="61" href="#">
             railties (7.2.3) lib/rails/engine.rb:535:in &#39;Rails::Engine#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="85" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="62" href="#">
             puma (7.2.0) lib/puma/configuration.rb:296:in &#39;Puma::Configuration::ConfigMiddleware#call&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="86" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="63" href="#">
             puma (7.2.0) lib/puma/request.rb:103:in &#39;block in Puma::Request#handle_request&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="87" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="64" href="#">
             puma (7.2.0) lib/puma/thread_pool.rb:355:in &#39;Puma::ThreadPool#with_force_shutdown&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="88" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="65" href="#">
             puma (7.2.0) lib/puma/request.rb:102:in &#39;Puma::Request#handle_request&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="89" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="66" href="#">
             puma (7.2.0) lib/puma/server.rb:503:in &#39;Puma::Server#process_client&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="90" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="67" href="#">
             puma (7.2.0) lib/puma/server.rb:262:in &#39;block in Puma::Server#run&#39;
           </a>
           <br>
-          <a class="trace-frames trace-frames-0" data-exception-object-id="10592" data-frame-id="91" href="#">
+          <a class="trace-frames trace-frames-0" data-exception-object-id="13576" data-frame-id="68" href="#">
             puma (7.2.0) lib/puma/thread_pool.rb:182:in &#39;block in Puma::ThreadPool#spawn_thread&#39;
           </a>
           <br>
@@ -3852,25 +2935,14 @@ content-length: 136719
   <!-- BEGIN /usr/local/bundle/gems/actionpack-7.2.3/lib/action_dispatch/middleware/templates/rescues/_request_and_response.html.erb --><h2 class="request-heading">Request</h2>
   <p><b>Parameters</b>:</p> <pre>{&quot;destination&quot; =&gt; &quot;Uac3b262f118636d67104eaf1f08aa1f7&quot;,
  &quot;events&quot; =&gt;
-  [{&quot;type&quot; =&gt; &quot;message&quot;,
-    &quot;message&quot; =&gt; {&quot;type&quot; =&gt; &quot;text&quot;, &quot;id&quot; =&gt; &quot;610291674870186380&quot;, &quot;quoteToken&quot; =&gt; &quot;[FILTERED]&quot;, &quot;markAsReadToken&quot; =&gt; &quot;[FILTERED]&quot;, &quot;text&quot; =&gt; &quot;あ&quot;},
-    &quot;webhookEventId&quot; =&gt; &quot;01KPJKJK8WA6H2SER1V2FG7K3T&quot;,
+  [{&quot;type&quot; =&gt; &quot;postback&quot;,
+    &quot;postback&quot; =&gt; {&quot;data&quot; =&gt; &quot;answer=%E3%82%A2&amp;question_number=9&amp;correct=%E3%82%A8&quot;},
+    &quot;webhookEventId&quot; =&gt; &quot;01KR8V7JTM9ZXX1JG2JX092VPG&quot;,
     &quot;deliveryContext&quot; =&gt; {&quot;isRedelivery&quot; =&gt; false},
-    &quot;timestamp&quot; =&gt; 1776593489082,
+    &quot;timestamp&quot; =&gt; 1778413455837,
     &quot;source&quot; =&gt; {&quot;type&quot; =&gt; &quot;user&quot;, &quot;userId&quot; =&gt; &quot;U8d7cfedfadd57affd87c896b4e586438&quot;},
     &quot;replyToken&quot; =&gt; &quot;[FILTERED]&quot;,
-    &quot;mode&quot; =&gt; &quot;active&quot;}],
- &quot;line_bot&quot; =&gt;
-  {&quot;destination&quot; =&gt; &quot;Uac3b262f118636d67104eaf1f08aa1f7&quot;,
-   &quot;events&quot; =&gt;
-    [{&quot;type&quot; =&gt; &quot;message&quot;,
-      &quot;message&quot; =&gt; {&quot;type&quot; =&gt; &quot;text&quot;, &quot;id&quot; =&gt; &quot;610291674870186380&quot;, &quot;quoteToken&quot; =&gt; &quot;[FILTERED]&quot;, &quot;markAsReadToken&quot; =&gt; &quot;[FILTERED]&quot;, &quot;text&quot; =&gt; &quot;あ&quot;},
-      &quot;webhookEventId&quot; =&gt; &quot;01KPJKJK8WA6H2SER1V2FG7K3T&quot;,
-      &quot;deliveryContext&quot; =&gt; {&quot;isRedelivery&quot; =&gt; false},
-      &quot;timestamp&quot; =&gt; 1776593489082,
-      &quot;source&quot; =&gt; {&quot;type&quot; =&gt; &quot;user&quot;, &quot;userId&quot; =&gt; &quot;U8d7cfedfadd57affd87c896b4e586438&quot;},
-      &quot;replyToken&quot; =&gt; &quot;[FILTERED]&quot;,
-      &quot;mode&quot; =&gt; &quot;active&quot;}]}}
+    &quot;mode&quot; =&gt; &quot;active&quot;}]}
 </pre>
 
 <div class="details">
@@ -3882,7 +2954,7 @@ content-length: 136719
   <div class="summary"><a href="#" onclick="return toggleEnvDump()">Toggle env dump</a></div>
   <div id="env_dump" class="hidden"><pre>GATEWAY_INTERFACE: &quot;CGI/1.2&quot;
 HTTP_ACCEPT_ENCODING: &quot;gzip&quot;
-HTTP_X_FORWARDED_FOR: &quot;147.92.150.197&quot;
+HTTP_X_FORWARDED_FOR: &quot;147.92.149.170&quot;
 HTTP_X_FORWARDED_HOST: &quot;amelia-monocultural-uncredulously.ngrok-free.dev&quot;
 ORIGINAL_SCRIPT_NAME: &quot;&quot;
 REMOTE_ADDR: &quot;172.19.0.1&quot;

--- a/render.yaml
+++ b/render.yaml
@@ -1,11 +1,11 @@
 services:
   - type: web
-    name: fe-line-bot
+    name: fetokku
     env: ruby
     region: singapore
     dockerfilePath: ./Dockerfile
     buildCommand: bundle install && bundle exec rails assets:precompile && bundle exec rails assets:clean && bundle exec rails db:migrate && bundle exec rails db:seed
-    startCommand: bundle exec rails db:seed && bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
+    startCommand: bundle exec puma -t 5:5 -p ${PORT:-3000} -e ${RACK_ENV:-development}
       - key: LINE_CHANNEL_SECRET
         sync: false
       - key: LINE_CHANNEL_TOKEN


### PR DESCRIPTION
## 概要
サービス名変更とstartCommandの修正

## 変更内容
- `name` を `fe-habit` → `fetokku` に変更
- `startCommand` から `bundle exec rails db:seed` を削除

## 変更理由
- サービス名をFetokkuに正式決定したため
- db:seedはデプロイ時に1回だけ実行されればよいため、
  buildCommandにのみ残しstartCommandからは削除