### PR TITLE
忘却曲線ロジックの実装

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -51,7 +51,7 @@ class LineBotController < ApplicationController
     when "履歴", "学習履歴", "成績"
      user = User.find_or_create_by(line_user_id: event.source.user_id)
      reply_text(event.reply_token, history_message(user))
-    when "設定"
+    when "設定を変える"
       reply_text(event.reply_token, "設定機能は準備中です。")
     else
       reply_text(event.reply_token, "下のメニューから操作してください。\n「問題を解く」で出題します！")
@@ -71,10 +71,10 @@ class LineBotController < ApplicationController
       }
 
       flex = FlexBuilder.question(
-        question_number:   q[:number],
-        question_text: q[:content],
-        choices:       choices,
-        correct:       q[:correct_answer]
+        question_number: q[:number],
+        question_text:   q[:content],
+        choices:         choices,
+        correct:         q[:correct_answer]
       )
 
       Rails.logger.info "=== flex: #{flex.inspect}"
@@ -115,6 +115,10 @@ class LineBotController < ApplicationController
           answer_choice: user_answer,
           is_correct: is_correct
         )
+
+        quality = is_correct ? 4 : 1
+        SpacedRepetitionService.call(answer, quality)
+        answer.save!
       end
 
       flex = FlexBuilder.result(

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -1,4 +1,15 @@
 class Answer < ApplicationRecord
-  belongs_to :user
-  belongs_to :question
+  # 今日以前にレビュー予定のものを取得
+  scope :due_for_review, -> { where("next_review_at <= ? OR next_review_at IS NULL", Time.current) }
+  scope :by_next_review, -> { order(:next_review_at) }
+
+  def needs_review?
+    next_review_at.nil? || next_review_at <= Time.current
+  end
+
+  def apply_review!(quality)
+    service = SpacedRepetitionService.new(self)
+    service.calculate_next_review(quality)
+    save!
+  end
 end

--- a/app/services/answer_recorder.rb
+++ b/app/services/answer_recorder.rb
@@ -1,7 +1,4 @@
 class AnswerRecorder
-  MAX_REVIEW_LEVEL = 5
-  MIN_REVIEW_LEVEL = 0
-
   def self.call(user:, question:, answer_choice:, is_correct:)
     new(
       user: user,
@@ -35,17 +32,5 @@ class AnswerRecorder
 
     answer.save!
     answer
-  end
-
-  private
-
-  def next_review_level(answer)
-    current = answer.review_level.to_i
-
-    if @is_correct
-      [ current + 1, MAX_REVIEW_LEVEL ].min
-    else
-      [ current - 1, MIN_REVIEW_LEVEL ].max
-    end
   end
 end

--- a/app/services/spaced_repetition_service.rb
+++ b/app/services/spaced_repetition_service.rb
@@ -1,0 +1,40 @@
+class SpacedRepetitionService
+  MIN_EASINESS_FACTOR = 1.3
+
+  def self.call(answer, quality)
+    new(answer).calculate_next_review(quality)
+  end
+
+  def initialize(answer)
+    @answer = answer
+  end
+
+  def calculate_next_review(quality)
+    if quality < 3
+      @answer.review_count = 0
+      @answer.interval_days = 1
+    else
+      @answer.interval_days = next_interval
+      @answer.review_count += 1
+    end
+
+    @answer.easiness_factor = updated_easiness_factor(quality)
+    @answer.next_review_at = Time.current + @answer.interval_days.days
+    @answer
+  end
+
+  private
+
+  def next_interval
+    case @answer.review_count
+    when 0 then 1
+    when 1 then 6
+    else (@answer.interval_days * @answer.easiness_factor).round
+    end
+  end
+
+  def updated_easiness_factor(quality)
+    ef = @answer.easiness_factor + (0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02))
+    [ ef, MIN_EASINESS_FACTOR ].max
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -18,5 +18,5 @@
 development:
   scheduled_push_job:
     class: ScheduledPushJob
-    schedule: "*/10 * * * *"   # 動作確認用：10分実行
+    schedule: "0 9 * * *"
     queue: default

--- a/db/migrate/20260603084226_change_review_count_default_on_answers.rb
+++ b/db/migrate/20260603084226_change_review_count_default_on_answers.rb
@@ -1,0 +1,6 @@
+class ChangeReviewCountDefaultOnAnswers < ActiveRecord::Migration[7.2]
+  def change
+    change_column_default :answers, :review_count, from: nil, to: 0
+    Answer.where(review_count: nil).update_all(review_count: 0)
+  end
+end

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_01_091849) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_03_084226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,12 +20,11 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_01_091849) do
     t.datetime "delivered_at"
     t.boolean "is_correct"
     t.datetime "last_answered_at"
-    t.integer "review_level"
+    t.integer "review_count", default: 0
     t.integer "answer_choice"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "next_review_at"
-    t.integer "review_count", default: 0, null: false
     t.integer "interval_days", default: 1, null: false
     t.float "easiness_factor", default: 2.5, null: false
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_01_091849) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_03_084226) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -20,7 +20,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_01_091849) do
     t.datetime "delivered_at"
     t.boolean "is_correct"
     t.datetime "last_answered_at"
-    t.integer "review_count"
+    t.integer "review_count", default: 0
     t.integer "answer_choice"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## 概要
SM-2アルゴリズムに基づく忘却曲線ロジックを実装し、回答履歴テーブルをSM-2対応のスキーマに移行しました。

## 変更内容

### DB
- `review_count` に `default: 0` を付与するマイグレーションを追加

### Answerモデル
- `due_for_review` スコープを追加（`next_review_at` が現在以前のレコードを取得）
- `by_next_review` スコープを追加（復習日順にソート）
- `needs_review?` メソッドを追加
- `apply_review!` メソッドを追加

### SpacedRepetitionService
- 新規作成
- SM-2アルゴリズムに基づき `interval_days` / `easiness_factor` / `next_review_at` を計算
- `self.call(answer, quality)` で呼び出せるインターフェースに統一

### AnswerRecorder
- `review_level` 関連コードを削除

### LineBotController
- `handle_postback` 内でSM-2の呼び出しを追加
- 正解時: quality = 4、不正解時: quality = 1

### recurring.yml
- 開発環境での配信時間を調整

## 動作確認
- Railsコンソールにて `SpacedRepetitionService.call` を実行し、`next_review_at` / `interval_days` / `easiness_factor` が正常に更新されることを確認済み

## 設計上のポイント
- コントローラは薄く保ち、SM-2計算は `SpacedRepetitionService`、回答保存は `AnswerRecorder` に委譲する関心の分離を意識しました。
- サービスクラスの呼び出しインターフェースを `クラス名.call(引数)` に統一しました。