### PR TITLE
AnswerRecorderのreview_level削除とhandle_postbackのanswer代入修正

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -109,7 +109,7 @@ class LineBotController < ApplicationController
       user = User.find_by(line_user_id: event.source.user_id)
 
       if user && q
-        AnswerRecorder.call(
+        answer = AnswerRecorder.call(
           user: user,
           question: q,
           answer_choice: user_answer,

--- a/app/services/answer_recorder.rb
+++ b/app/services/answer_recorder.rb
@@ -26,8 +26,7 @@ class AnswerRecorder
     answer.assign_attributes(
       answer_choice: @answer_choice,
       is_correct: @is_correct,
-      last_answered_at: Time.current,
-      review_level: next_review_level(answer)
+      last_answered_at: Time.current
     )
 
     answer.save!


### PR DESCRIPTION
## 概要
`AnswerRecorder` に残っていた `review_level` 関連コードを削除し、`LineBotController` の `handle_postback` で `answer` の代入漏れを修正しました。

## 背景
前のPRで `review_level` カラムを廃止しSM-2カラムへ移行しましたが、`AnswerRecorder` 内に `review_level` 関連コードが残存していました。また `handle_postback` で `AnswerRecorder.call` の戻り値を受け取っておらず、SM-2処理時に `answer` が未定義となる500エラーが発生していました。

## 変更内容

### AnswerRecorder
- `assign_attributes` 内の `review_level: next_review_level(answer)` を削除

### LineBotController
- `AnswerRecorder.call` の戻り値を `answer =` で受け取るよう修正
- これにより `SpacedRepetitionService.call(answer, quality)` が正常に動作するように修正

## 動作確認
- LINEから問題に回答し、正誤判定が正常に返ることを確認済み