### PR TITLE
compose.ymlにLIFF_ID環境変数を追加

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -33,6 +33,8 @@ services:
       RAILS_ENV: development
       ADMIN_USER: admin
       ADMIN_PASSWORD: 1234
+      LIFF_ID_SETTINGS: ${LIFF_ID_SETTINGS} 
+      LIFF_ID_HISTORY: ${LIFF_ID_HISTORY} 
     ports:
       - "3000:3000"
     depends_on:
@@ -54,6 +56,8 @@ services:
       RAILS_ENV: development
       ADMIN_USER: admin
       ADMIN_PASSWORD: 1234
+      LIFF_ID_SETTINGS: ${LIFF_ID_SETTINGS} 
+      LIFF_ID_HISTORY: ${LIFF_ID_HISTORY} 
     depends_on:
       - web
 volumes:


### PR DESCRIPTION
## 概要
開発環境でLIFFアプリが動作するよう、compose.ymlに環境変数を追加した。

## 変更内容
- `web`・`worker`サービスに`LIFF_ID_SETTINGS`、`LIFF_ID_HISTORY`を追加
- `.env`から`${LIFF_ID_SETTINGS}`・`${LIFF_ID_HISTORY}`を参照する形式で設定

## 背景
`.env`にLIFF IDは記載済みだったが、`compose.yml`の`environment`に渡す設定が
漏れており、コンテナ内で環境変数が未定義になっていた。
その結果、`liff.init()`に空文字が渡され、LIFFアプリが起動しない状態だった。

## 確認事項
- [x] `docker compose exec web env | grep LIFF`で環境変数が表示されることを確認
- [x] PCブラウザでLIFF画面が表示されることを確認