### PR TITLE
LIFF配信設定画面のUIをリデザイン

### DIFF
--- a/app/controllers/liff/settings_controller.rb
+++ b/app/controllers/liff/settings_controller.rb
@@ -1,4 +1,5 @@
 class Liff::SettingsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [ :update, :current ]
   layout "liff"
   def index
   end

--- a/app/views/layouts/liff.html.erb
+++ b/app/views/layouts/liff.html.erb
@@ -10,6 +10,11 @@
 
   <%= csrf_meta_tags %>
   <%= stylesheet_link_tag 'application', media: 'all' %>
+  
+  <!-- Google Fonts -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 <body>
   <%= yield %>

--- a/app/views/liff/settings/index.html.erb
+++ b/app/views/liff/settings/index.html.erb
@@ -1,33 +1,310 @@
 <div id="liff-app">
-  <p>読み込み中...</p>
+  <p style="text-align:center; padding: 40px; color: #888;">読み込み中...</p>
 </div>
 
-<script>
-  const LIFF_ID = "<%= ENV['LIFF_ID_SETTINGS'] %>";
+<div id="toast" style="
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(80px);
+  background: #43a047; color: #fff; padding: 12px 24px;
+  border-radius: 24px; font-size: 14px; font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  opacity: 0; white-space: nowrap; z-index: 999;
+">✓ 設定を保存しました</div>
 
-  // 時間の選択肢を生成（00:00〜23:30、30分刻み）
-  function buildTimeOptions(selectedValue) {
-    let options = '<option value="">未設定</option>';
-    for (let h = 0; h < 24; h++) {
-      for (let m of ["00", "30"]) {
-        const value = `${String(h).padStart(2, "0")}:${m}`;
-        const selected = value === selectedValue ? "selected" : "";
-        options += `<option value="${value}" ${selected}>${value}</option>`;
-      }
-    }
-    return options;
+<style>
+  body { background: #e8eaf6; margin: 0; font-family: 'Noto Sans JP', sans-serif; }
+
+  .liff-wrap { padding: 12px; max-width: 390px; margin: 0 auto; }
+
+  .header-card {
+    background: #fff;
+    border-radius: 14px;
+    padding: 14px 16px;
+    margin-bottom: 10px;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .header-icon {
+    width: 42px; height: 42px; border-radius: 10px;
+    background: #e8eaf6;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .header-icon svg { width: 24px; height: 24px; }
+  .header-title { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0; }
+  .header-sub   { font-size: 12px; color: #888; margin: 3px 0 0; }
+  .header-deco  { margin-left: auto; font-size: 30px; }
+
+  .setting-card {
+    background: #fff;
+    border-radius: 14px;
+    padding: 14px 16px;
+    margin-bottom: 10px;
+  }
+  .setting-row {
+    display: flex; align-items: center; gap: 10px; margin-bottom: 12px;
+  }
+  .setting-icon {
+    width: 36px; height: 36px; border-radius: 8px;
+    display: flex; align-items: center; justify-content: center;
+    flex-shrink: 0;
+  }
+  .setting-icon.purple { background: #ede7f6; }
+  .setting-icon.orange { background: #fff3e0; }
+  .setting-label { font-size: 11px; color: #888; margin: 0; }
+  .setting-value { font-size: 18px; font-weight: 600; margin: 1px 0 0; }
+  .setting-value.purple { color: #5c6bc0; }
+  .setting-value.orange { color: #ef6c00; }
+  .setting-desc  { font-size: 11px; color: #bbb; margin: 1px 0 0; }
+
+  select {
+    width: 100%; padding: 9px 12px; font-size: 14px;
+    border: 1px solid #e0e0e0; border-radius: 10px;
+    background: #f8f8ff; color: #333;
+    appearance: none; -webkit-appearance: none;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24'%3E%3Cpath fill='%23888' d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+    background-repeat: no-repeat; background-position: right 12px center;
+    cursor: pointer;
+    font-family: 'Noto Sans JP', sans-serif;
   }
 
-  // DBの時刻文字列（"2000-01-01T09:00:00+09:00"）から "HH:MM" を取り出す
+  .freq-btns { display: flex; gap: 6px; }
+  .freq-btn {
+    flex: 1; padding: 9px 4px; text-align: center;
+    border-radius: 10px; font-size: 13px; cursor: pointer;
+    border: 1px solid #e0e0e0;
+    background: #f5f5f5; color: #999;
+    transition: all 0.15s;
+    -webkit-tap-highlight-color: transparent;
+    font-family: 'Noto Sans JP', sans-serif;
+  }
+  .freq-btn.active {
+    border: 2px solid #5c6bc0;
+    background: #e8eaf6; color: #5c6bc0; font-weight: 600;
+  }
+
+  .hint-box {
+    background: #fff8e1; border-radius: 10px;
+    border: 1px solid #ffe082;
+    padding: 10px 12px; margin-bottom: 10px;
+    display: flex; align-items: center; gap: 8px;
+    font-size: 12px; color: #795548;
+  }
+
+  .btn-save {
+    width: 100%; padding: 13px; border-radius: 12px;
+    background: #5c6bc0; border: none; color: #fff;
+    font-size: 15px; font-weight: 600; cursor: pointer;
+    margin-bottom: 8px;
+    -webkit-tap-highlight-color: transparent;
+    font-family: 'Noto Sans JP', sans-serif;
+  }
+  .btn-save:active { opacity: 0.85; }
+
+  .btn-history {
+    width: 100%; padding: 12px; border-radius: 12px;
+    background: #fff; border: 2px solid #5c6bc0;
+    color: #5c6bc0; font-size: 14px; font-weight: 600;
+    cursor: pointer; display: flex; align-items: center;
+    justify-content: center; gap: 8px;
+    -webkit-tap-highlight-color: transparent;
+    font-family: 'Noto Sans JP', sans-serif;
+  }
+  .btn-history:active { opacity: 0.85; }
+
+  #error-message {
+    text-align: center; margin-top: 8px;
+    font-size: 13px; color: #e53935; min-height: 18px;
+  }
+</style>
+
+<script>
+  const LIFF_ID_SETTINGS = "<%= ENV['LIFF_ID_SETTINGS'] %>";
+  const LIFF_ID_HISTORY  = "<%= ENV['LIFF_ID_HISTORY'] %>";
+
+  function showToast() {
+    const toast = document.getElementById("toast");
+    toast.style.opacity = "1";
+    toast.style.transform = "translateX(-50%) translateY(0)";
+    setTimeout(() => {
+      toast.style.opacity = "0";
+      toast.style.transform = "translateX(-50%) translateY(80px)";
+    }, 2500);
+  }
+
+  function buildTimeOptions(selectId, selectedValue) {
+    const el = document.getElementById(selectId);
+    el.innerHTML = '<option value="">未設定</option>';
+    for (let h = 0; h < 24; h++) {
+      for (let m of ["00", "30"]) {
+        const v = `${String(h).padStart(2, "0")}:${m}`;
+        const opt = document.createElement("option");
+        opt.value = v;
+        opt.textContent = v;
+        if (v === selectedValue) opt.selected = true;
+        el.appendChild(opt);
+      }
+    }
+  }
+
   function parseTime(datetimeStr) {
     if (!datetimeStr) return "";
     const date = new Date(datetimeStr);
-    const h = String(date.getHours()).padStart(2, "0");
-    const m = String(date.getMinutes()).padStart(2, "0");
-    return `${h}:${m}`;
+    return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
   }
 
-  liff.init({ liffId: LIFF_ID })
+  function renderApp(data, lineUserId) {
+    const time1 = parseTime(data.delivery_time_1);
+    const time2 = parseTime(data.delivery_time_2);
+    const freq  = data.frequency || "daily";
+    const freqLabel = { daily: "毎日", weekday: "平日のみ", weekend: "土日のみ" };
+
+    document.getElementById("liff-app").innerHTML = `
+      <div class="liff-wrap">
+
+        <div class="header-card">
+          <div class="header-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#5c6bc0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+            </svg>
+          </div>
+          <div>
+            <p class="header-title">学習設定</p>
+            <p class="header-sub">あなたの学習スタイルに合わせて設定を変更できます</p>
+          </div>
+          <div class="header-deco">📖</div>
+        </div>
+
+        <div class="setting-card">
+          <div class="setting-row">
+            <div class="setting-icon orange">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#ef6c00" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
+              </svg>
+            </div>
+            <div>
+              <p class="setting-label">配信頻度</p>
+              <p class="setting-value orange" id="freq-display">${freqLabel[freq]}</p>
+              <p class="setting-desc">通知を受け取る頻度を設定します</p>
+            </div>
+          </div>
+          <div class="freq-btns">
+            <div class="freq-btn ${freq === 'daily'   ? 'active' : ''}" data-value="daily">毎日</div>
+            <div class="freq-btn ${freq === 'weekday' ? 'active' : ''}" data-value="weekday">平日のみ</div>
+            <div class="freq-btn ${freq === 'weekend' ? 'active' : ''}" data-value="weekend">土日のみ</div>
+          </div>
+          <input type="hidden" id="frequency" value="${freq}">
+        </div>
+
+        <div class="setting-card">
+          <div class="setting-row">
+            <div class="setting-icon purple">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#7e57c2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+              </svg>
+            </div>
+            <div>
+              <p class="setting-label">配信時間①（必須）</p>
+              <p class="setting-value purple" id="time1-display">${time1 || "-- : --"}</p>
+              <p class="setting-desc">1日の中で通知を受け取る時刻を設定します</p>
+            </div>
+          </div>
+          <select id="delivery_time_1"></select>
+        </div>
+
+        <div class="setting-card">
+          <div class="setting-row">
+            <div class="setting-icon purple">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#7e57c2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+              </svg>
+            </div>
+            <div>
+              <p class="setting-label">配信時間②（任意）</p>
+              <p class="setting-value purple" id="time2-display">${time2 || "-- : --"}</p>
+              <p class="setting-desc">2回目の通知時刻（設定しない場合は空欄）</p>
+            </div>
+          </div>
+          <select id="delivery_time_2"></select>
+        </div>
+
+        <div class="hint-box">
+          💡 設定した内容は、学習の出題や通知に反映されます。
+        </div>
+
+        <button class="btn-save" id="save-btn">保存する</button>
+
+        <button class="btn-history" id="history-btn">
+          📊 学習状況を確認する ›
+        </button>
+
+        <p id="error-message"></p>
+      </div>
+    `;
+
+    buildTimeOptions("delivery_time_1", time1);
+    buildTimeOptions("delivery_time_2", time2);
+
+    document.getElementById("delivery_time_1").addEventListener("change", function () {
+      document.getElementById("time1-display").textContent = this.value || "-- : --";
+    });
+    document.getElementById("delivery_time_2").addEventListener("change", function () {
+      document.getElementById("time2-display").textContent = this.value || "-- : --";
+    });
+
+    const freqLabels = { daily: "毎日", weekday: "平日のみ", weekend: "土日のみ" };
+    document.querySelectorAll(".freq-btn").forEach((btn) => {
+      btn.addEventListener("click", function () {
+        document.querySelectorAll(".freq-btn").forEach((b) => b.classList.remove("active"));
+        this.classList.add("active");
+        document.getElementById("frequency").value = this.dataset.value;
+        document.getElementById("freq-display").textContent = freqLabels[this.dataset.value];
+      });
+    });
+
+    document.getElementById("save-btn").addEventListener("click", () => {
+      const frequency       = document.getElementById("frequency").value;
+      const delivery_time_1 = document.getElementById("delivery_time_1").value;
+      const delivery_time_2 = document.getElementById("delivery_time_2").value;
+
+      if (!delivery_time_1) {
+        document.getElementById("error-message").textContent = "配信時間①は必須です";
+        return;
+      }
+      document.getElementById("error-message").textContent = "";
+
+      fetch("/liff/settings", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          line_user_id: lineUserId,
+          frequency,
+          delivery_time_1,
+          delivery_time_2: delivery_time_2 || null,
+        }),
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`サーバーエラー: ${res.status}`);
+          return res.json();
+        })
+        .then(() => {
+          showToast();
+        })
+        .catch((err) => {
+          document.getElementById("error-message").textContent = `エラーが発生しました: ${err.message}`;
+        });
+    });
+
+    document.getElementById("history-btn").addEventListener("click", () => {
+      liff.openWindow({
+        url: `https://liff.line.me/${LIFF_ID_HISTORY}`,
+        external: false,
+      });
+    });
+  }
+
+  liff.init({ liffId: LIFF_ID_SETTINGS })
     .then(() => {
       if (!liff.isLoggedIn()) {
         liff.login();
@@ -37,102 +314,17 @@
     })
     .then((profile) => {
       if (!profile) return;
-
       const lineUserId = profile.userId;
 
-      // 現在の設定をRailsから取得
       return fetch("/liff/settings/current?line_user_id=" + lineUserId)
         .then((res) => {
           if (!res.ok) throw new Error(`サーバーエラー: ${res.status}`);
           return res.json();
         })
-        .then((data) => {
-          const time1 = parseTime(data.delivery_time_1);
-          const time2 = parseTime(data.delivery_time_2);
-
-          const frequencyOptions = [
-            { value: "daily",   label: "毎日" },
-            { value: "weekday", label: "平日のみ" },
-            { value: "weekend", label: "土日のみ" },
-          ];
-
-          const radioButtons = frequencyOptions.map(({ value, label }) => {
-            const checked = data.frequency === value ? "checked" : "";
-            return `
-              <label>
-                <input type="radio" name="frequency" value="${value}" ${checked}>
-                ${label}
-              </label>
-            `;
-          }).join("");
-
-          document.getElementById("liff-app").innerHTML = `
-            <div style="padding: 20px;">
-              <h2>配信設定</h2>
-
-              <div style="margin-bottom: 20px;">
-                <p><strong>配信頻度</strong></p>
-                <div style="display: flex; flex-direction: column; gap: 8px;">
-                  ${radioButtons}
-                </div>
-              </div>
-
-              <div style="margin-bottom: 20px;">
-                <p><strong>配信時間①（必須）</strong></p>
-                <select id="delivery_time_1">
-                  ${buildTimeOptions(time1)}
-                </select>
-              </div>
-
-              <div style="margin-bottom: 20px;">
-                <p><strong>配信時間②（任意）</strong></p>
-                <select id="delivery_time_2">
-                  ${buildTimeOptions(time2)}
-                </select>
-              </div>
-
-              <button id="save-btn" style="padding: 10px 20px;">保存する</button>
-              <p id="message" style="margin-top: 10px;"></p>
-            </div>
-          `;
-
-          // 保存ボタン
-          document.getElementById("save-btn").addEventListener("click", () => {
-            const frequency = document.querySelector('input[name="frequency"]:checked')?.value;
-            const delivery_time_1 = document.getElementById("delivery_time_1").value;
-            const delivery_time_2 = document.getElementById("delivery_time_2").value;
-
-            if (!delivery_time_1) {
-              document.getElementById("message").textContent = "配信時間①は必須です";
-              return;
-            }
-
-            fetch("/liff/settings", {
-              method: "PATCH",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                line_user_id: lineUserId,
-                frequency,
-                delivery_time_1,
-                delivery_time_2: delivery_time_2 || null,
-              }),
-            })
-              .then((res) => {
-                if (!res.ok) throw new Error(`サーバーエラー: ${res.status}`);
-                return res.json();
-              })
-              .then((result) => {
-                document.getElementById("message").textContent = result.message;
-              })
-              .catch((err) => {
-                document.getElementById("message").textContent = `エラーが発生しました: ${err.message}`;
-              });
-          });
-        });
+        .then((data) => renderApp(data, lineUserId));
     })
-    .catch((err) => {                         // ← 44行・110行のfetchを拾う
-      console.error("LIFF初期化エラー:", err);
-      document.getElementById("liff-app").textContent =
-        `エラーが発生しました: ${err.message}`;
+    .catch((err) => {
+      console.error("LIFFエラー:", err);
+      document.getElementById("liff-app").textContent = `エラーが発生しました: ${err.message}`;
     });
 </script>

--- a/lib/tasks/line_rich_menu.rake
+++ b/lib/tasks/line_rich_menu.rake
@@ -22,7 +22,7 @@ namespace :line do
         },
         {
           bounds: { x: 1667, y: 0, width: 833, height: 843 },
-          action: { type: "message", label: "設定", text: "設定" }
+          action: { type: "uri", label: "設定", uri: "https://liff.line.me/#{ENV.fetch('LIFF_ID_SETTINGS')}" }
         }
       ]
     }
@@ -100,7 +100,7 @@ namespace :line do
         },
         {
           bounds: { x: 1667, y: 0, width: 833, height: 843 },
-          action: { type: "message", label: "設定", text: "設定" }
+          action: { type: "uri", label: "設定", uri: "https://liff.line.me/#{ENV.fetch('LIFF_ID_SETTINGS')}" }
         }
       ]
     }


### PR DESCRIPTION
## 概要
LIFF配信設定画面のUIをリデザインし、視覚的にわかりやすい画面に改善した。

## 変更内容
- `lib/tasks/line.rake`: リッチメニューの「設定」ボタンのアクションを`message`から`uri`に変更し、LIFFアプリを直接開けるようにした
- `app/views/liff/settings.html.erb`: UIを全面リデザイン
  - ヘッダーカード・設定カードのコンポーネント構成に変更
  - ラジオボタンをタップしやすいボタン形式に変更
  - 保存成功時にトースト通知（画面下からポップアップ）を表示
  - Noto Sans JPフォントを適用しスマホ表示を統一
  - 「学習状況を確認する」ボタンを追加（履歴LIFF遷移用、実装は別途）
- `app/controllers/liff/settings_controller.rb`: `skip_before_action :verify_authenticity_token`を追加

## 確認事項
- [x] リッチメニューの「設定」ボタンからLIFF画面が開くことを確認
- [x] 配信設定の保存が正常に動作することを確認
- [x] トースト通知が表示されることを確認
- [x] スマホ・PCブラウザ両方で表示を確認