### PR TITLE
配信設定画面にバリデーションとトースト通知を追加

### DIFF
--- a/app/models/delivery_setting.rb
+++ b/app/models/delivery_setting.rb
@@ -6,4 +6,14 @@ class DeliverySetting < ApplicationRecord
   validates :frequency, presence: true
   validates :delivery_time_1, presence: true
   validates :user_id, uniqueness: true
+  validate :delivery_times_must_differ
+
+  private
+
+  def delivery_times_must_differ
+    return if delivery_time_2.blank?
+    if delivery_time_1 == delivery_time_2
+      errors.add(:deliverry_time_2, "は配信時間①と異なる時刻を設定してください")
+    end
+  end
 end

--- a/app/views/liff/settings/index.html.erb
+++ b/app/views/liff/settings/index.html.erb
@@ -4,64 +4,68 @@
 
 <div id="toast" style="
   position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(80px);
-  background: #43a047; color: #fff; padding: 12px 24px;
-  border-radius: 24px; font-size: 14px; font-weight: 600;
+  background: #43a047; color: #fff; padding: 10px 22px;
+  border-radius: 24px; font-size: 13px; font-weight: 600;
   box-shadow: 0 4px 12px rgba(0,0,0,0.15);
   transition: transform 0.3s ease, opacity 0.3s ease;
   opacity: 0; white-space: nowrap; z-index: 999;
 ">✓ 設定を保存しました</div>
 
+<div id="toast-error" style="
+  position: fixed; bottom: 24px; left: 50%; transform: translateX(-50%) translateY(80px);
+  background: #e53935; color: #fff; padding: 10px 22px;
+  border-radius: 24px; font-size: 13px; font-weight: 600;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  opacity: 0; white-space: nowrap; z-index: 999;
+">✕ <span id="toast-error-message"></span></div>
+
 <style>
-  body { background: #e8eaf6; margin: 0; font-family: 'Noto Sans JP', sans-serif; }
+  body { background: #f0f2f0; margin: 0; font-family: 'Noto Sans JP', sans-serif; }
 
   .liff-wrap { padding: 12px; max-width: 390px; margin: 0 auto; }
 
-  .header-card {
-    background: #fff;
-    border-radius: 14px;
-    padding: 14px 16px;
-    margin-bottom: 10px;
+  .header-area {
+    padding: 8px 4px 12px;
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
   }
   .header-icon {
-    width: 42px; height: 42px; border-radius: 10px;
-    background: #e8eaf6;
+    width: 36px; height: 36px;
     display: flex; align-items: center; justify-content: center;
     flex-shrink: 0;
   }
-  .header-icon svg { width: 24px; height: 24px; }
-  .header-title { font-size: 16px; font-weight: 600; color: #1a1a2e; margin: 0; }
-  .header-sub   { font-size: 12px; color: #888; margin: 3px 0 0; }
-  .header-deco  { margin-left: auto; font-size: 30px; }
+  .header-title { font-size: 18px; font-weight: 700; color: #1a1a2e; margin: 0; }
+  .header-sub   { font-size: 11px; color: #888; margin: 2px 0 0; }
+  .header-deco  { margin-left: auto; font-size: 28px; }
 
   .setting-card {
     background: #fff;
     border-radius: 14px;
-    padding: 14px 16px;
-    margin-bottom: 10px;
+    padding: 12px 14px;
+    margin-bottom: 8px;
   }
   .setting-row {
-    display: flex; align-items: center; gap: 10px; margin-bottom: 12px;
+    display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
   }
   .setting-icon {
-    width: 36px; height: 36px; border-radius: 8px;
+    width: 34px; height: 34px; border-radius: 8px;
     display: flex; align-items: center; justify-content: center;
     flex-shrink: 0;
   }
-  .setting-icon.purple { background: #ede7f6; }
+  .setting-icon.green  { background: #e8f5e9; }
   .setting-icon.orange { background: #fff3e0; }
   .setting-label { font-size: 11px; color: #888; margin: 0; }
-  .setting-value { font-size: 18px; font-weight: 600; margin: 1px 0 0; }
-  .setting-value.purple { color: #5c6bc0; }
+  .setting-value { font-size: 17px; font-weight: 700; margin: 1px 0 0; }
+  .setting-value.green  { color: #43a047; }
   .setting-value.orange { color: #ef6c00; }
   .setting-desc  { font-size: 11px; color: #bbb; margin: 1px 0 0; }
 
   select {
-    width: 100%; padding: 9px 12px; font-size: 14px;
+    width: 100%; padding: 8px 12px; font-size: 14px;
     border: 1px solid #e0e0e0; border-radius: 10px;
-    background: #f8f8ff; color: #333;
+    background: #f9f9f9; color: #333;
     appearance: none; -webkit-appearance: none;
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24'%3E%3Cpath fill='%23888' d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
     background-repeat: no-repeat; background-position: right 12px center;
@@ -71,8 +75,8 @@
 
   .freq-btns { display: flex; gap: 6px; }
   .freq-btn {
-    flex: 1; padding: 9px 4px; text-align: center;
-    border-radius: 10px; font-size: 13px; cursor: pointer;
+    flex: 1; padding: 8px 4px; text-align: center;
+    border-radius: 8px; font-size: 13px; cursor: pointer;
     border: 1px solid #e0e0e0;
     background: #f5f5f5; color: #999;
     transition: all 0.15s;
@@ -80,21 +84,21 @@
     font-family: 'Noto Sans JP', sans-serif;
   }
   .freq-btn.active {
-    border: 2px solid #5c6bc0;
-    background: #e8eaf6; color: #5c6bc0; font-weight: 600;
+    border: 2px solid #43a047;
+    background: #e8f5e9; color: #43a047; font-weight: 600;
   }
 
   .hint-box {
-    background: #fff8e1; border-radius: 10px;
-    border: 1px solid #ffe082;
-    padding: 10px 12px; margin-bottom: 10px;
+    background: #f9fbe7; border-radius: 10px;
+    border: 1px solid #e6ee9c;
+    padding: 9px 12px; margin-bottom: 8px;
     display: flex; align-items: center; gap: 8px;
-    font-size: 12px; color: #795548;
+    font-size: 11px; color: #795548;
   }
 
   .btn-save {
-    width: 100%; padding: 13px; border-radius: 12px;
-    background: #5c6bc0; border: none; color: #fff;
+    width: 100%; padding: 12px; border-radius: 12px;
+    background: #43a047; border: none; color: #fff;
     font-size: 15px; font-weight: 600; cursor: pointer;
     margin-bottom: 8px;
     -webkit-tap-highlight-color: transparent;
@@ -103,20 +107,15 @@
   .btn-save:active { opacity: 0.85; }
 
   .btn-history {
-    width: 100%; padding: 12px; border-radius: 12px;
-    background: #fff; border: 2px solid #5c6bc0;
-    color: #5c6bc0; font-size: 14px; font-weight: 600;
+    width: 100%; padding: 11px; border-radius: 12px;
+    background: #fff; border: 2px solid #43a047;
+    color: #43a047; font-size: 14px; font-weight: 600;
     cursor: pointer; display: flex; align-items: center;
     justify-content: center; gap: 8px;
     -webkit-tap-highlight-color: transparent;
     font-family: 'Noto Sans JP', sans-serif;
   }
   .btn-history:active { opacity: 0.85; }
-
-  #error-message {
-    text-align: center; margin-top: 8px;
-    font-size: 13px; color: #e53935; min-height: 18px;
-  }
 </style>
 
 <script>
@@ -133,7 +132,34 @@
     }, 2500);
   }
 
-  function buildTimeOptions(selectId, selectedValue) {
+  function showErrorToast(message) {
+    const toast = document.getElementById("toast-error");
+    document.getElementById("toast-error-message").textContent = message;
+    toast.style.opacity = "1";
+    toast.style.transform = "translateX(-50%) translateY(0)";
+    setTimeout(() => {
+      toast.style.opacity = "0";
+      toast.style.transform = "translateX(-50%) translateY(80px)";
+    }, 3000);
+  }
+
+  // 配信時間①用（未設定なし）
+  function buildTimeOptionsRequired(selectId, selectedValue) {
+    const el = document.getElementById(selectId);
+    el.innerHTML = '';
+    for (let h = 0; h < 24; h++) {
+      for (let m of ["00", "30"]) {
+        const v = `${String(h).padStart(2, "0")}:${m}`;
+        const opt = document.createElement("option");
+        opt.value = v;
+        opt.textContent = v;
+        if (v === selectedValue) opt.selected = true;
+        el.appendChild(opt);
+      }
+    }
+  }
+  // 配信時間②用（未設定あり）
+  function buildTimeOptionsOptional(selectId, selectedValue) {
     const el = document.getElementById(selectId);
     el.innerHTML = '<option value="">未設定</option>';
     for (let h = 0; h < 24; h++) {
@@ -163,9 +189,9 @@
     document.getElementById("liff-app").innerHTML = `
       <div class="liff-wrap">
 
-        <div class="header-card">
+        <div class="header-area">
           <div class="header-icon">
-            <svg viewBox="0 0 24 24" fill="none" stroke="#5c6bc0" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <svg viewBox="0 0 24 24" fill="none" stroke="#43a047" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" width="28" height="28">
               <circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
             </svg>
           </div>
@@ -173,7 +199,7 @@
             <p class="header-title">学習設定</p>
             <p class="header-sub">あなたの学習スタイルに合わせて設定を変更できます</p>
           </div>
-          <div class="header-deco">📖</div>
+          <div class="header-deco">⏰</div>
         </div>
 
         <div class="setting-card">
@@ -186,7 +212,6 @@
             <div>
               <p class="setting-label">配信頻度</p>
               <p class="setting-value orange" id="freq-display">${freqLabel[freq]}</p>
-              <p class="setting-desc">通知を受け取る頻度を設定します</p>
             </div>
           </div>
           <div class="freq-btns">
@@ -199,15 +224,14 @@
 
         <div class="setting-card">
           <div class="setting-row">
-            <div class="setting-icon purple">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#7e57c2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <div class="setting-icon green">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#43a047" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
               </svg>
             </div>
             <div>
               <p class="setting-label">配信時間①（必須）</p>
-              <p class="setting-value purple" id="time1-display">${time1 || "-- : --"}</p>
-              <p class="setting-desc">1日の中で通知を受け取る時刻を設定します</p>
+              <p class="setting-value green" id="time1-display">${time1 || "-- : --"}</p>
             </div>
           </div>
           <select id="delivery_time_1"></select>
@@ -215,15 +239,14 @@
 
         <div class="setting-card">
           <div class="setting-row">
-            <div class="setting-icon purple">
-              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#7e57c2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <div class="setting-icon green">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#43a047" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                 <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
               </svg>
             </div>
             <div>
               <p class="setting-label">配信時間②（任意）</p>
-              <p class="setting-value purple" id="time2-display">${time2 || "-- : --"}</p>
-              <p class="setting-desc">2回目の通知時刻（設定しない場合は空欄）</p>
+              <p class="setting-value green" id="time2-display">${time2 || "-- : --"}</p>
             </div>
           </div>
           <select id="delivery_time_2"></select>
@@ -238,13 +261,11 @@
         <button class="btn-history" id="history-btn">
           📊 学習状況を確認する ›
         </button>
-
-        <p id="error-message"></p>
       </div>
     `;
 
-    buildTimeOptions("delivery_time_1", time1);
-    buildTimeOptions("delivery_time_2", time2);
+    buildTimeOptionsRequired("delivery_time_1", time1);
+    buildTimeOptionsOptional("delivery_time_2", time2);
 
     document.getElementById("delivery_time_1").addEventListener("change", function () {
       document.getElementById("time1-display").textContent = this.value || "-- : --";
@@ -268,11 +289,10 @@
       const delivery_time_1 = document.getElementById("delivery_time_1").value;
       const delivery_time_2 = document.getElementById("delivery_time_2").value;
 
-      if (!delivery_time_1) {
-        document.getElementById("error-message").textContent = "配信時間①は必須です";
+      if (delivery_time_2 && delivery_time_1 === delivery_time_2) {
+        showErrorToast("配信時間②は配信時間①と異なる時刻を設定してください");
         return;
       }
-      document.getElementById("error-message").textContent = "";
 
       fetch("/liff/settings", {
         method: "PATCH",
@@ -284,15 +304,16 @@
           delivery_time_2: delivery_time_2 || null,
         }),
       })
-        .then((res) => {
-          if (!res.ok) throw new Error(`サーバーエラー: ${res.status}`);
-          return res.json();
-        })
-        .then(() => {
-          showToast();
+        .then((res) => res.json())
+        .then((result) => {                 
+          if (result.errors) {
+            showErrorToast(result.errors.join("、"));
+          } else {
+            showToast();
+          }
         })
         .catch((err) => {
-          document.getElementById("error-message").textContent = `エラーが発生しました: ${err.message}`;
+          showErrorToast(`エラーが発生しました: ${err.message}`);
         });
     });
 


### PR DESCRIPTION
## 概要
LIFF配信設定画面にバリデーションとフィードバックUIを追加した。

## 変更内容

### バリデーション
**フロント（settings.html.erb）**
- 配信時間①の選択肢から「未設定」を削除
- 配信時間②が入力された場合、配信時間①と重複していないかチェック

**サーバー（delivery_setting.rb）**
- `delivery_times_must_differ` カスタムバリデーションを追加
- 配信時間②が設定されている場合、配信時間①と異なる値であることを検証

### フィードバックUI
- 保存成功時：画面下から緑のトースト通知（2.5秒で自動消去）
- 保存失敗時：画面下から赤のトースト通知（3秒で自動消去）
- サーバーエラーのレスポンス（422）も `result.errors` として受け取りトーストで表示

## 設計上の判断
配信時間①は必須項目のため「未設定」の選択肢を表示すること自体がUX上の矛盾と判断し、フロント側の必須バリデーションではなく選択肢の削除で対応した。ただしサーバー側のバリデーション（`presence: true`）は直接API呼び出し対策として引き続き維持している。

## 確認事項
- [x] 配信時間①②が同じ時刻のときエラートーストが表示されることを確認
- [x] 保存成功時に緑のトーストが表示されることを確認
- [x] サーバー側バリデーションエラーがトーストで表示されることを確認