### PR TITLE
使い方ページを追加

### DIFF
--- a/app/controllers/liff/help_controller.rb
+++ b/app/controllers/liff/help_controller.rb
@@ -1,0 +1,6 @@
+module Liff
+  class HelpController < ApplicationController
+    def index
+    end
+  end
+end

--- a/app/views/liff/help/index.html.erb
+++ b/app/views/liff/help/index.html.erb
@@ -1,0 +1,87 @@
+<style>
+  body {
+    background: #f0f2f0;
+    margin: 0;
+    font-family: 'Noto Sans JP', sans-serif;
+  }
+
+  .help-wrap {
+    padding: 12px;
+    max-width: 390px;
+    margin: 0 auto;
+  }
+
+  .help-card {
+    background: #fff;
+    border-radius: 14px;
+    padding: 16px;
+    margin-bottom: 10px;
+  }
+
+  .help-card h2 {
+    margin-top: 0;
+    font-size: 16px;
+  }
+
+  .help-card p {
+    color: #555;
+    line-height: 1.7;
+  }
+
+  .feature {
+    background: #fff8e1;
+  }
+
+  .back-link {
+    display: block;
+    text-align: center;
+    margin-top: 16px;
+    color: #42a5f5;
+    text-decoration: none;
+    font-weight: 600;
+  }
+</style>
+
+<div class="help-container">
+  <h1>🦉 fetokkuの使い方</h1>
+
+  <div class="help-card">
+    <h2>① 学習設定</h2>
+    <p>
+      配信頻度と配信時間を設定します。
+    </p>
+  </div>
+
+  <div class="help-card">
+    <h2>② 問題を解く</h2>
+    <p>
+      設定した時間になると問題が届きます。
+      メニューからいつでも学習することもできます。
+    </p>
+  </div>
+
+  <div class="help-card">
+    <h2>③ 学習履歴</h2>
+    <p>
+      正解率や学習記録を確認できます。
+    </p>
+  </div>
+
+  <div class="help-card feature">
+    <h2>📚 fetokkuの特徴</h2>
+
+    <p>
+      回答結果に応じて問題を自動で再出題します。
+    </p>
+
+    <p>
+      苦手な問題は早めに、
+      正解した問題は忘れた頃に出題されるため、
+      効率よく復習できます。
+    </p>
+  </div>
+
+  <button onclick="history.back()">
+    ← 戻る
+  </button>
+</div>

--- a/app/views/liff/settings/index.html.erb
+++ b/app/views/liff/settings/index.html.erb
@@ -261,6 +261,10 @@
         <button class="btn-history" id="history-btn">
           📊 学習状況を確認する ›
         </button>
+
+        <a href="/liff/help" class="help-link">
+          ❓使い方を見る
+         </a>
       </div>
     `;
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     get "settings", to: "settings#index"
     get "settings/current", to: "settings#current"
     get "history",  to: "history#index"
+    get "help", to: "help#index"
     patch "settings", to: "settings#update"
   end
 


### PR DESCRIPTION
# 概要

学習設定画面から遷移できる「使い方ページ」を追加しました。

# 変更内容

* `/liff/help` を追加
* HelpController を作成
* 使い方ページのビューを作成
* 学習設定画面に「使い方を見る」リンクを追加

# 使い方ページの内容

* 学習設定の説明
* 問題の解き方
* 学習履歴の確認方法
* fetokkuの特徴（回答結果に応じた自動再出題）

# 目的

初めて利用するユーザーがアプリの利用方法や特徴を理解しやすくするため。

# 動作確認

* [x] 学習設定画面から使い方ページへ遷移できること
* [x] 使い方ページが正常に表示されること
* [x] 戻る操作で学習設定画面へ戻れること
