### PR TITLE
トークン生成ロジック実装

### DIFF
--- a/app/controllers/liff/history_controller.rb
+++ b/app/controllers/liff/history_controller.rb
@@ -1,14 +1,36 @@
 class Liff::HistoryController < ApplicationController
   skip_before_action :verify_authenticity_token
   layout "liff"
+  before_action :set_user, except: [ :index ]
 
   def index
   end
 
   def data
-    user = User.find_by(line_user_id: session[:line_user_id])
-    return render json: { error: "ユーザーが見つかりません" }, status: :not_found unless user
+    render json: Liff::HistoryAggregator.new(@user).call
+  end
 
-    render json: Liff::HistoryAggregator.new(user).call
+  def create_share_token
+    aggregate_result = Liff::HistoryAggregator.new(@user).call
+    summary = aggregate_result[:summary]
+
+    share_token = @user.share_tokens.create!(
+      snapshot_data: {
+        accuracy_rate: summary[:accuracy_rate],
+        total_study_days: summary[:total_study_days],
+        mastery_rate: summary[:mastery_rate],
+        total_answers: summary[:total_answers]
+    }
+  )
+
+  render json: { share_url: "#{request.base_url}/share/#{share_token.token}" }
+end
+
+private
+
+  def set_user
+    @user= User.find_by(line_user_id: session[:line_user_id])
+
+    render json: { error: "ユーザーが見つかりません" }, status: :not_found unless @user
   end
 end

--- a/app/models/share_token.rb
+++ b/app/models/share_token.rb
@@ -1,0 +1,25 @@
+# app/models/share_token.rb
+class ShareToken < ApplicationRecord
+  belongs_to :user
+
+  before_validation :generate_token, on: :create
+  before_validation :set_expiration, on: :create
+
+  validates :token, presence: true, uniqueness: true
+
+  EXPIRATION_PERIOD = 30.days
+
+  def expired?
+    expires_at < Time.current
+  end
+
+  private
+
+  def generate_token
+    self.token ||= SecureRandom.urlsafe_base64(32)
+  end
+
+  def set_expiration
+    self.expires_at ||= EXPIRATION_PERIOD.from_now
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,4 +12,5 @@ class User < ApplicationRecord
   belongs_to :current_question, class_name: "Question", optional: true
   has_one :delivery_setting
   has_many :answers
+  has_many :share_tokens, dependent: :destroy
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
     get "settings/current", to: "settings#current"
     get "history",  to: "history#index"
     get "history/data", to: "history#data"
+    post "history/share_tokens", to: "history#create_share_token"
     get "help", to: "help#index"
     patch "settings", to: "settings#update"
   end

--- a/db/migrate/20260617151418_create_share_tokens.rb
+++ b/db/migrate/20260617151418_create_share_tokens.rb
@@ -1,0 +1,14 @@
+class CreateShareTokens < ActiveRecord::Migration[7.2]
+  def change
+    create_table :share_tokens do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :token, null: false
+      t.jsonb :snapshot_data, null: false, default: {}
+      t.datetime :expires_at, null: false
+
+      t.timestamps
+    end
+
+    add_index :share_tokens, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2026_06_07_033753) do
+ActiveRecord::Schema[7.2].define(version: 2026_06_17_151418) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,17 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_07_033753) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "year"
+  end
+
+  create_table "share_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", null: false
+    t.jsonb "snapshot_data", default: {}, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_share_tokens_on_token", unique: true
+    t.index ["user_id"], name: "index_share_tokens_on_user_id"
   end
 
   create_table "solid_queue_blocked_executions", force: :cascade do |t|
@@ -183,6 +194,7 @@ ActiveRecord::Schema[7.2].define(version: 2026_06_07_033753) do
     t.integer "state"
   end
 
+  add_foreign_key "share_tokens", "users"
   add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade

--- a/spec/requests/liff/history_spec.rb
+++ b/spec/requests/liff/history_spec.rb
@@ -1,10 +1,38 @@
 require 'rails_helper'
 
-RSpec.describe "Liff::Histories", type: :request do
-  describe "GET /index" do
-    it "returns http success" do
-      get "/liff/history/index"
-      expect(response).to have_http_status(:success)
+RSpec.describe "Liff::History", type: :request do
+  let(:user) { User.create!(line_user_id: "U1234567890", name: "テストユーザー") }
+
+  describe "POST /liff/history/share_tokens" do
+    before do
+      allow_any_instance_of(Liff::HistoryController).to receive(:set_user) do |controller|
+        controller.instance_variable_set(:@user, user)
+      end
+    end
+
+    it "share_tokenが新規作成される" do
+      expect {
+        post "/liff/history/share_tokens"
+      }.to change(ShareToken, :count).by(1)
+    end
+
+    it "正答率・学習日数・定着率・総回答数がsnapshot_dataに保存される" do
+      question = Question.create!(content: "テスト問題", correct_answer: "1")
+      Answer.create!(user: user, question: question, is_correct: true)
+
+      post "/liff/history/share_tokens"
+
+      share_token = ShareToken.last
+      expect(share_token.snapshot_data).to include(
+        "accuracy_rate", "total_study_days", "mastery_rate", "total_answers"
+      )
+    end
+
+    it "share_urlがレスポンスに含まれる" do
+      post "/liff/history/share_tokens"
+
+      json = JSON.parse(response.body)
+      expect(json["share_url"]).to include("/share/")
     end
   end
 end


### PR DESCRIPTION
## 概要
OGP共有機能の第一段階として、共有トークン発行ロジックを実装した。

Closes #【Issue165】

## 変更内容
- `share_tokens`テーブルを追加（user_id, token, snapshot_data, expires_at）
- `ShareToken`モデルを追加
  - `SecureRandom.urlsafe_base64(32)`でトークンを自動生成
  - 有効期限は30日（Xでの再シェア頻度の低さと、学習記録としての情報鮮度を考慮して設定）
  - DBのユニークインデックス + アプリ側バリデーションでトークンの一意性を保証
- `POST /liff/history/share_tokens` エンドポイントを追加
  - `Liff::HistoryAggregator`の集計結果をスナップショットとして保存
  - 共有ページ（別Issueで実装予定）にはまだ依存しないよう、`share_url`はURLヘルパーを使わず文字列で組み立てている

## 設計判断
- トークンを1カラムで持つ方式ではなく、専用テーブルに分離した
- シェアごとに新しいトークンを発行し、過去の共有リンクが上書きで無効化されない設計
- snapshot_dataに共有時点の統計を保存する方式にした
- アクセス時点で再計算すると「共有した時点の記録」と表示内容がズレるため

## テスト
- `spec/requests/liff/history_spec.rb` を追加
  - トークンが新規作成されること
  - snapshot_dataに正答率・学習日数・定着率・総回答数が保存されること
  - share_urlがレスポンスに含まれること

## 残課題（別Issueで対応予定）
- `/share/:token` の共有ページ実装
- 期限切れトークンの定期削除（Solid Queue）