### PR TITLE
X共有ボタンの実装とOGP/Twitter Card対応 (#145)

### DIFF
--- a/app/views/layouts/public.html.erb
+++ b/app/views/layouts/public.html.erb
@@ -10,7 +10,11 @@
   <meta property="og:image" content="<%= yield(:og_image) %>">
   <meta property="og:url" content="<%= request.original_url %>">
   <meta property="og:type" content="website">
+
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="<%= yield(:og_title) %>">
+  <meta name="twitter:description" content="<%= yield(:og_description) %>">
+  <meta name="twitter:image" content="<%= yield(:og_image) %>">
 
   <%= stylesheet_link_tag "application" %>
 </head>

--- a/app/views/liff/history/index.html.erb
+++ b/app/views/liff/history/index.html.erb
@@ -1,4 +1,4 @@
-<%= render "shared/history_dashboard" %>
+<%= render "shared/history_dashboard", share_section: :own %>
 <%= render "shared/history_chart_scripts" %>
 
 <script>

--- a/app/views/shared/_history_dashboard.html.erb
+++ b/app/views/shared/_history_dashboard.html.erb
@@ -288,9 +288,16 @@ body {
   height: 48px;
   border-radius: 50%;
   border: none;
+  background: #000;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.share-btn:disabled {
   background: #eee;
   color: #aaa;
-  font-size: 10px;
   cursor: not-allowed;
 }
 
@@ -384,7 +391,50 @@ body {
     <div class="share-section">
       <div class="share-title">学習の記録をXでシェアしよう！</div>
       <div class="share-buttons">
-        <button class="share-btn" disabled>X</button>
+        <button class="share-btn" id="x-share-btn">X</button>
       </div>
     </div>
   <% end %>
+</div><!-- ← .history-container を閉じる（もともと無かったので追加） -->
+
+<script>
+  document.addEventListener('DOMContentLoaded', function () {
+    const shareBtn = document.getElementById('x-share-btn');
+    if (!shareBtn) return;
+
+    shareBtn.addEventListener('click', async function () {
+      shareBtn.disabled = true;
+      shareBtn.textContent = "...";
+
+      try {
+        const response = await fetch('/liff/history/share_tokens', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'same-origin'
+        });
+
+        if (!response.ok) {
+          throw new Error('share_token request failed');
+        }
+
+        const data = await response.json();
+        const shareUrl = data.share_url;
+
+        const tweetText = "基本情報技術者試験、学習を続けています📚";
+
+        const intentUrl = "https://twitter.com/intent/tweet"
+          + "?text=" + encodeURIComponent(tweetText)
+          + "&url=" + encodeURIComponent(shareUrl);
+
+        liff.openWindow({ url: intentUrl, external: true });
+
+      } catch (error) {
+        console.error(error);
+        alert("シェア用リンクの作成に失敗しました。時間をおいて再度お試しください。");
+      } finally {
+        shareBtn.disabled = false;
+        shareBtn.textContent = "X";
+      }
+    });
+  });
+</script>


### PR DESCRIPTION
## 概要
学習成果をXに共有する機能を実装しました。
LINE内シェア（shareTargetPicker）は「学習履歴をLINEの友だちに送る意味が薄い」
という判断から本Issueのスコープ外とし、X共有のみで完結させています。

Closes #145

## 変更内容
- `_history_dashboard.html.erb` にXシェアボタンの動作を実装
  - クリック時に `/liff/history/share_tokens` を呼んでShareTokenを発行
  - 取得した共有URLでX intent URL（`https://twitter.com/intent/tweet`）を組み立て、
    `liff.openWindow({ external: true })` で開く
- `public.html.erb` にTwitter Card用metaタグを追加
  - `twitter:card` / `twitter:title` / `twitter:description` / `twitter:image`
- 既存の不具合を修正
  - `.history-container` の閉じタグ漏れ
  - `render` 時に `share_section` が渡っておらず `NameError` になっていた問題

## スコープ外（別Issue管理）
- 利用規約｜プライバシーポリシーのフッターリンクが自分の履歴画面に表示されない不具合：
  本PRの変更とは無関係の既存バグのため、別Issueで対応予定

## 動作確認
- [x] LIFFからXシェアボタン押下→X投稿画面が開き、URL付きで投稿できることを実機で確認
- [x] `curl -A "Twitterbot/1.0"` でTwitter Card用metaタグが正しく出力されることを確認
- [x] `og_image` エンドポイントが画像を正常に返すことを確認
- [ ] X上での画像プレビュー表示は、ngrok無料プランのインタースティシャル制限により
      ローカルでは確認不可。本番デプロイ後に確認予定