### PR TITLE
LIFFクイズのFlexMessageデザインを刷新し、出典表記を追加

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -84,7 +84,8 @@ class LineBotController < ApplicationController
         question_number: q[:number],
         question_text:   q[:content],
         choices:         choices,
-        correct:         q[:correct_answer]
+        correct:         q[:correct_answer],
+        year:            q[:year]
       )
 
       Rails.logger.info "=== flex: #{flex.inspect}"

--- a/app/jobs/deliver_question_job.rb
+++ b/app/jobs/deliver_question_job.rb
@@ -56,7 +56,8 @@ class DeliverQuestionJob < ApplicationJob
       question_number: question.number,
       question_text:   question.content,
       choices:         choices,
-      correct:         question.correct_answer
+      correct:         question.correct_answer,
+      year:             question.year
     )
 
     client = Line::Bot::V2::MessagingApi::ApiClient.new(

--- a/app/jobs/scheduled_push_job.rb
+++ b/app/jobs/scheduled_push_job.rb
@@ -22,9 +22,10 @@ class ScheduledPushJob < ApplicationJob
 
     flex = FlexBuilder.question(
       question_number: q[:number],
-      question_text: q[:content],
-      choices:       choices,
-      correct:       q[:correct_answer]
+      question_text:   q[:content],
+      choices:         choices,
+      correct:         q[:correct_answer],
+      year:            q[:year]
     )
 
     User.find_each do |user|

--- a/app/services/flex_builder.rb
+++ b/app/services/flex_builder.rb
@@ -1,13 +1,27 @@
 require "uri"
 
 module FlexBuilder
-  def self.question(question_number:, question_text:, choices:, correct:)
-    rows = choices.map do |label, text|
-      {
-        "type"     => "box",
-        "layout"   => "horizontal",
-        "margin"   => "md",
-        "action"   => {
+  BADGE_BG_COLOR  = "#EAF1FB" # バッジの薄い背景色
+  BADGE_TEXT_COLOR = "#2E6BB5" # バッジ・正解文字の色
+  PRIMARY_COLOR    = "#3E7FDC" # 「解説を見る」ボタン
+  BORDER_COLOR     = "#D9E2EC" # 「次の問題へ」の枠線
+  GRAY_BG          = "#E3E6EA" # 「終了する」の背景
+
+  def self.question(question_number:, question_text:, choices:, correct:,
+                     year:, subject: "科目A")
+    period = year.to_i <= 2019 ? "秋期" : nil
+    source_text = [ "出典：IPA FE試験 #{year}年", period, subject, "問#{question_number}" ].compact.join(" ")
+
+    rows = []
+    choices.each_with_index do |(label, text), i|
+      rows << {
+        "type"          => "box",
+        "layout"        => "horizontal",
+        "spacing"       => "md",
+        "paddingTop"    => i.zero? ? "md" : "lg",
+        "paddingBottom" => "lg",
+        "alignItems"    => "center",
+        "action"        => {
           "type"        => "postback",
           "label"       => label,
           "data"        => URI.encode_www_form([
@@ -19,22 +33,38 @@ module FlexBuilder
         },
         "contents" => [
           {
-            "type"  => "text",
-            "text"  => label,
-            "size"  => "sm",
-            "color" => "#555555",
-            "flex"  => 1
+            "type"            => "box",
+            "layout"          => "vertical",
+            "width"           => "26px",
+            "height"          => "26px",
+            "cornerRadius"    => "6px",
+            "backgroundColor" => BADGE_BG_COLOR,
+            "justifyContent"  => "center",
+            "alignItems"      => "center",
+            "contents"        => [
+              {
+                "type"   => "text",
+                "text"   => label,
+                "size"   => "sm",
+                "color"  => BADGE_TEXT_COLOR,
+                "weight" => "bold",
+                "align"  => "center"
+              }
+            ]
           },
           {
-            "type"  => "text",
-            "text"  => text.to_s,
-            "size"  => "sm",
-            "color" => "#111111",
-            "flex"  => 5,
-            "wrap"  => true
+            "type"    => "text",
+            "text"    => text.to_s,
+            "size"    => "sm",
+            "wrap"   => true,
+            "color"   => "#333333",
+            "flex"    => 1,
+            "wrap"    => true,
+            "gravity" => "center"
           }
         ]
       }
+      rows << { "type" => "separator", "color" => "#EEEEEE" } unless i == choices.size - 1
     end
 
     {
@@ -54,17 +84,58 @@ module FlexBuilder
               "size"  => "sm",
               "color" => "#333333"
             },
-            { "type" => "separator", "margin" => "md" }
+            {
+              "type"   => "text",
+              "text"   => source_text,
+              "size"   => "xs",
+              "color"  => "#999999",
+              "margin" => "lg"
+            },
+            { "type" => "separator", "margin" => "lg" }
           ] + rows
         }
       }
     }
   end
 
-  def self.result(is_correct:, correct:, question_id:, explanation_url: nil)
-    result_text = is_correct \
-      ? "⭕ 正解！ 正解は #{correct} です"
-      : "❌ 不正解... 正解は #{correct} でした"
+  def self.result(is_correct:, correct:, question_id:, explanation_url: nil, character_image_url: nil)
+    icon_span  = is_correct ? { "text" => "⭕ ", "color" => "#2EBD59" } : { "text" => "❌ ", "color" => "#FF4D4F" }
+    label_span = is_correct ? { "text" => "正解！ 答えは " } : { "text" => "不正解… 正解は " }
+
+    result_contents = [
+      {
+        "type"     => "text",
+        "wrap"     => true,
+        "size"     => "md",
+        "color"    => "#333333",
+        "contents" => [
+          icon_span.merge("type" => "span"),
+          label_span.merge("type" => "span"),
+          { "type" => "span", "text" => correct, "color" => BADGE_TEXT_COLOR, "weight" => "bold" },
+          { "type" => "span", "text" => is_correct ? " でした！" : " でした" }
+        ]
+      }
+    ]
+
+    body_contents = []
+
+    if character_image_url
+      body_contents << {
+        "type"        => "image",
+        "url"         => character_image_url,
+        "size"        => "sm",
+        "aspectMode"  => "fit",
+        "aspectRatio" => "1:1",
+        "align"       => "center"
+      }
+    end
+
+    body_contents << {
+      "type"       => "box",
+      "layout"     => "vertical",
+      "paddingAll" => "16px",
+      "contents"   => result_contents
+    }
 
     {
       "type"     => "flex",
@@ -72,25 +143,10 @@ module FlexBuilder
       "contents" => {
         "type" => "bubble",
         "body" => {
-          "type"       => "box",
-          "layout"     => "vertical",
-          "spacing"    => "md",
-          "contents"   => [
-            {
-              "type"       => "box",
-              "layout"     => "vertical",
-              "paddingAll" => "16px",
-              "contents"   => [
-                {
-                  "type"  => "text",
-                  "text"  => result_text,
-                  "wrap"  => true,
-                  "size"  => "md",
-                  "color" => "#333333"
-                }
-              ]
-            }
-          ]
+          "type"     => "box",
+          "layout"   => "vertical",
+          "spacing"  => "md",
+          "contents" => body_contents
         },
         "footer" => {
           "type"     => "box",
@@ -98,37 +154,62 @@ module FlexBuilder
           "spacing"  => "sm",
           "contents" => [
             {
-              "type"   => "button",
-              "style"  => "primary",
-              "height" => "sm",
-              "action" => {
+              "type"            => "box",
+              "layout"          => "horizontal",
+              "paddingAll"      => "12px",
+              "cornerRadius"    => "lg",
+              "backgroundColor" => PRIMARY_COLOR,
+              "justifyContent"  => "center",
+              "spacing"         => "sm",
+              "action"          => {
                 "type"  => "uri",
                 "label" => "解説を見る",
                 "uri"   => explanation_url || "https://www.fe-siken.com/fe/"
-              }
+              },
+              "contents" => [
+                { "type" => "text", "text" => "📖", "color" => "#FFFFFF", "flex" => 0 },
+                { "type" => "text", "text" => "解説を見る", "color" => "#FFFFFF", "weight" => "bold", "align" => "center", "size" => "md" }
+              ]
             },
             {
-              "type"   => "button",
-              "style"  => "secondary",
-              "height" => "sm",
-              "action" => {
+              "type"            => "box",
+              "layout"          => "horizontal",
+              "paddingAll"      => "12px",
+              "cornerRadius"    => "lg",
+              "backgroundColor" => "#FFFFFF",
+              "borderWidth"     => "1px",
+              "borderColor"     => BORDER_COLOR,
+              "justifyContent"  => "center",
+              "alignItems"      => "center",
+              "action"          => {
                 "type"        => "postback",
                 "label"       => "次の問題へ",
                 "data"        => "action=next",
                 "displayText" => "次の問題へ"
-              }
+              },
+              "contents" => [
+                { "type" => "text", "text" => "次の問題へ", "color" => "#333333", "weight" => "bold", "size" => "md", "align" => "center", "flex" => 1 },
+                { "type" => "text", "text" => "›", "color" => PRIMARY_COLOR, "weight" => "bold", "size" => "lg", "flex" => 0 }
+              ]
             },
             {
-              "type"   => "button",
-              "style"  => "secondary",
-              "height" => "sm",
-              "color"  => "#aaaaaa",
-              "action" => {
+              "type"            => "box",
+              "layout"          => "horizontal",
+              "paddingAll"      => "12px",
+              "cornerRadius"    => "lg",
+              "backgroundColor" => GRAY_BG,
+              "justifyContent"  => "center",
+              "spacing"         => "sm",
+              "action"          => {
                 "type"        => "postback",
                 "label"       => "終了する",
                 "data"        => "action=end",
                 "displayText" => "終了する"
-              }
+              },
+              "contents" => [
+                { "type" => "text", "text" => "⏹", "color" => "#777777", "flex" => 0 },
+                { "type" => "text", "text" => "終了する", "color" => "#777777", "weight" => "bold", "align" => "center", "size" => "md" }
+              ]
             }
           ]
         }

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,6 +4,9 @@ Dir[Rails.root.join('db/csv/*.csv')].each do |file|
   url_path = File.basename(file, '.csv')
   Rails.logger.info "Importing #{url_path}..."
 
+  reiwa_number = url_path[/\A\d+/].to_i
+  year = 2018 + reiwa_number # 令和N年 = 2018 + N
+
   CSV.foreach(file, headers: true, encoding: 'BOM|UTF-8') do |row|
     number = row['number'].to_i
 
@@ -15,11 +18,12 @@ Dir[Rails.root.join('db/csv/*.csv')].each do |file|
       q.choice_2        = row['choice_2']
       q.choice_3        = row['choice_3']
       q.choice_4        = row['choice_4']
+      q.year            = year
       q.explanation_url = row['explanation_url'].presence&.strip ||
         "https://www.fe-siken.com/kakomon/#{url_path}/q#{number}.html"
       q.save!
     end
   end
 
-  puts "#{url_path}: インポート完了（合計 #{Question.count} 件）"
+  puts "#{url_path}: インポート完了（year=#{year}, 合計 #{Question.count} 件）"
 end


### PR DESCRIPTION
## 概要
LIFFクイズで送信するFlexMessage（出題・正誤判定）の見た目を全面的に見直しました。
カード型の選択肢デザインを試した後、よりシンプルなバッジ＋罫線方式に変更し、出典表記（年度・科目・問番号）を新たに追加しています。（Issue#178）

## 変更内容

### デザイン刷新
- 選択肢（ア〜エ）：円形の塗りバッジ→**角丸の控えめなバッジ**（薄い背景色＋色文字）に変更
- 選択肢間の区切りをカードの枠線ではなく**罫線（separator）**に統一
- 正誤判定メッセージのボタンを以下のデザインに統一
  - 解説を見る：塗り青ボタン
  - 次の問題へ：白背景＋枠線＋矢印
  - 終了する：グレー塗りボタン
- 正誤判定メッセージにキャラクター画像を差し込めるオプションを追加（`character_image_url`引数、未指定時は非表示）

### 出典表記の追加
- 問題文の下部に「2019年 秋期 科目A 問1」のような出典を小さめ・薄文字で表示
- `questions`テーブルに`year`カラムを追加
- CSVファイル名（`01_aki.csv`など先頭の令和年数字）から西暦年を自動算出してseed時に投入
- `period`（春期／秋期）はカラムを持たず、`FlexBuilder`側で`year <= 2019`の場合のみ「秋期」と表示する形で都度算出（CBT化以降は期の区分がないため）

## 変更ファイル
- `app/services/flex_builder.rb`：選択肢・正誤判定メッセージのデザイン刷新、出典表記ロジック追加
- `db/seeds.rb`：ファイル名から`year`を算出して投入する処理を追加
- `db/migrate/xxxx_add_year_to_questions.rb`：`year`カラム追加
- `app/controllers/line_bot_controller.rb` `app/jobs/scheduled_push_job.rb`  `app/jobs/deliver_question_job.rb`：`FlexBuilder.question`呼び出しに`year:`を追加

## 動作確認
- [x] LINEアプリ実機（iPhone Safari含む）で出題・正誤判定メッセージの表示を確認
- [x] `docker compose exec app bundle exec rails runner db/seeds.rb` 実行後、既存問題に`year`が正しく入ることを確認
- [x] 01_aki / 05_menjo それぞれで出典表記が想定通り（秋期あり／なし）になることを確認

## 残課題（別Issue切り出し予定）
- キャラクター画像の実画像・公開URLの用意（現状はオプション引数のみ実装済み、未使用）