### PR TITLE
FlexBuilder警告修正・初回配信ジョブのenqueue追加

### DIFF
--- a/app/controllers/liff/settings_controller.rb
+++ b/app/controllers/liff/settings_controller.rb
@@ -18,8 +18,13 @@ class Liff::SettingsController < ApplicationController
     return render json: { error: "ユーザーが見つかりません" }, status: :not_found unless user
 
     setting = DeliverySetting.find_or_initialize_by(user_id: user.id)
+    is_new_setting = setting.new_record?
 
     if setting.update(delivery_setting_params)
+      if is_new_setting
+        next_time = DeliveryTimeCalculator.call(setting)
+        DeliverQuestionJob.set(wait_until: next_time).perform_later(user.id) if next_time
+      end
       render json: { message: "保存しました" }, status: :ok
     else
       render json: { errors: setting.errors.full_messages }, status: :unprocessable_entity

--- a/app/services/flex_builder.rb
+++ b/app/services/flex_builder.rb
@@ -59,7 +59,6 @@ module FlexBuilder
             "wrap"   => true,
             "color"   => "#333333",
             "flex"    => 1,
-            "wrap"    => true,
             "gravity" => "center"
           }
         ]


### PR DESCRIPTION
### 概要
`FlexBuilder`の軽微な警告修正と、Cron-job.orgから `Solid Queue` への移行に伴う「配信設定保存時の初回ジョブ起動」処理の追加を行います。

### 変更内容

* **FlexBuilder**: 重複していたHashキー `wrap` の記述を削除。
    * 59行目と62行目で同じキーが指定されており、後勝ちで62行目が有効になっていたため、62行目を削除しました。
* **Liff::SettingsController#update**: 配信設定を新規作成した時のみ、`DeliveryTimeCalculator` で次回配信時刻を算出し、`DeliverQuestionJob` を `wait_until` 付きで enqueue する処理を追加。
    * 既存ユーザーが設定を変更しただけの場合は重複起動しないよう、`setting.new_record?` で分岐処理を行いました。

### 背景
Cron-job.org（外部cronサービス）から `Solid Queue` への配信方式移行作業の一環です。

* Cron-job.orgは「全ユーザーまとめて1日1回」しか配信できない制約がありましたが、ユーザーごとに異なる配信時刻・頻度を実現するため、`Solid Queue` の `DeliverQuestionJob`（`wait_until` による自己連鎖方式）へ切り替えます。
* これまでは全ユーザー分を一括起動する `recurring.yml` が唯一の起動トリガーだったため、ユーザーが配信設定を保存した時点で個別に初回ジョブを起動する仕組みが必要となりました。

### 動作確認
- [x] 本番環境で `FlexBuilder` の警告が出ないことを確認
- [ ] 配信設定を新規保存した際に、ログに「次回スケジュール」が出力されることを確認
- [ ] 既存ユーザーへの初回ジョブ一括 enqueue（ワンショットスクリプト実行）
- [ ] `recurring.yml` の `scheduled_push_job` エントリ削除
- [ ] `Api::QuizController`・関連route・`ScheduledPushJob` 本体の削除
- [ ] Cron-job.org のジョブ停止

### 補足
本PRは移行作業全体の前半部分です。既存ユーザーの配信を止めないよう、上記未完了タスクは「既存ユーザーへの初回enqueueが完了してから、旧経路（`recurring.yml`・`quiz_controller`・`ScheduledPushJob`）を削除する」という順序で別途対応予定です。