### PR TITLE
application.jsのcontrollersインポートを相対パスに修正

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,3 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
-import "controllers"
+import "./controllers"


### PR DESCRIPTION
## 概要
Render上でのビルドが `Could not resolve "controllers"` エラーで失敗していたのを修正しました。（Issue#196）

## 原因
`app/javascript/application.js` 内で `import "controllers"` と記述していたため、
esbuildがこれをnpmパッケージ名と解釈し、解決できずビルドが失敗していました。
ローカル環境では `NODE_PATH` の設定により動作していましたが、
Render環境には同設定がないため発生していました。

## 修正内容
- `import "controllers"` → `import "./controllers"` に変更(相対パスを明示)

## 動作確認
- [ ] ローカルで `yarn build` が通ることを確認
- [ ] Render上のビルドログで `yarn build` / `yarn build:css` が成功することを確認
- [ ] 本番で `/liff/history` 等のLIFF画面が正常に表示されることを確認

## 関連
Build Commandの変更(`yarn build`・`yarn build:css`・`assets:precompile` の追加)は
Render側の設定変更のため、コード変更には含まれません。