### PR TITLE
fix: LIFFセッション作成時の401エラーを修正

### DIFF
--- a/app/controllers/liff/sessions_controller.rb
+++ b/app/controllers/liff/sessions_controller.rb
@@ -4,12 +4,16 @@ class Liff::SessionsController < ApplicationController
   def create
     id_token = params[:id_token]
 
+    if id_token.blank?
+      return render json: { error: "IDトークンがありません" }, status: :bad_request
+    end
+
     # LINE APIでIDトークンを検証する
     response = Faraday.post("https://api.line.me/oauth2/v2.1/verify") do |req|
       req.headers["Content-Type"] = "application/x-www-form-urlencoded"
       req.body = URI.encode_www_form(
         id_token: id_token,
-        client_id: ENV.fetch("LINE_LOGIN_CHANNEL_ID")
+        client_id: ENV.fetch("LIFF_CHANNEL_ID")
       )
     end
 
@@ -19,8 +23,11 @@ class Liff::SessionsController < ApplicationController
       return render json: { error: "トークンの検証に失敗しました" }, status: :unauthorized
     end
 
-    # セッションにline_user_idを保存
-    session[:line_user_id] = result["sub"]  # "sub" がLINEユーザーID
+    if result["sub"].blank?
+      return render json: { error: "LINEユーザーIDを取得できませんでした" }, status: :unauthorized
+    end
+
+    session[:line_user_id] = result["sub"] # "sub" がLINEユーザーID
 
     render json: { ok: true }
   end


### PR DESCRIPTION
## 概要
学習履歴・設定画面のLIFFで発生していた「セッションの作成に失敗しました」エラー(401 Unauthorized)を修正しました。

## 原因と対応

### openidスコープの未設定(401 Unauthorized)
LINE Developersコンソールの「学習履歴」「設定」LIFFアプリ設定で、scopeに`openid`がチェックされていなかったため、IDトークン検証が401で失敗していました。
→ コンソール側でscopeに`openid` `profile`を追加

### 環境変数名の整理
`client_id`に渡すチャネルIDの環境変数名が`LINE_LOGIN_CHANNEL_ID`となっており用途が分かりにくかったため、`LIFF_CHANNEL_ID`にリネームし命名をわかりやすくしました。

## 確認方法
- [x] 「学習履歴」LIFFを開き、セッションエラーが出ずにヒートマップ等が表示されること
- [x] 「設定」LIFFを開き、セッションエラーが出ずに設定画面が表示されること
- [x] Renderの環境変数`LIFF_CHANNEL_ID`が設定されていることを確認済み