### PR TITLE
fix: LINE友だち再フォロー時に配信ジョブが重複する問題を修正

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -28,6 +28,7 @@ class LineBotController < ApplicationController
       case event
       when Line::Bot::V2::Webhook::FollowEvent
         user = User.find_or_create_by(line_user_id: event.source.user_id)
+        is_new_user = user.delivery_setting.nil?
 
         # デフォルトの配信設定を作成（再登録時は既存設定を使う）
         setting = user.delivery_setting || user.create_delivery_setting!(
@@ -35,9 +36,11 @@ class LineBotController < ApplicationController
           delivery_time_1: Time.zone.parse("09:00")
         )
 
-        # 初回配信ジョブを積む
-        first_delivery = DeliveryTimeCalculator.call(setting)
-        DeliverQuestionJob.set(wait_until: first_delivery).perform_later(user.id) if first_delivery
+        # 初回配信ジョブを積む（新規ユーザーのみ。再フォロー時は既にジョブが動いているため、二重に積まないようにする）
+        if is_new_user
+          first_delivery = DeliveryTimeCalculator.call(setting)
+          DeliverQuestionJob.set(wait_until: first_delivery).perform_later(user.id) if first_delivery
+        end
 
       when Line::Bot::V2::Webhook::MessageEvent
         case event.message


### PR DESCRIPTION
## 概要
LINE公式アカウントの再フォロー(ブロック解除)時に、配信ジョブ
(`DeliverQuestionJob`)が重複登録される不具合を修正しました。

Closes #(200)

## 原因
`LineBotController`の`FollowEvent`処理で、新規ユーザーか既存ユーザー
(再フォロー)かを判定せず、`FollowEvent`が発火するたびに無条件で
`DeliverQuestionJob`を`perform_later`していました。

リッチメニュー反映確認のため実機で複数回「ブロック→解除」を行った結果、同一ユーザーに対して独立した配信チェインが3本同時に動作し、
同じ問題が1日に3回配信される状態になっていました。

## 対応
- `user.delivery_setting`の有無で新規ユーザーかどうかを判定し、
  初回フォロー時のみジョブを積むように修正
- 本番DBに残っていた重複ジョブ(3件中2件)は、Renderの本番コンソールから手動で削除して応急処置済み

## 動作確認
- [x] 既存ユーザーが「ブロック→解除」してもジョブが増えないこと
      (`SolidQueue::ScheduledExecution`の件数が変化しないこと)
- [ ] 新規ユーザーがフォローした場合は、初回ジョブが正しく1件登録
      されること
- [ ] 既存ユーザーの配信が継続して届くこと