### PR TITLE
OGPシェア画像で正答率・定着率の数値が表示されない不具合を修正

### DIFF
--- a/app/controllers/public/shares_controller.rb
+++ b/app/controllers/public/shares_controller.rb
@@ -20,7 +20,9 @@ module Public
     def og_image
       share_token = ShareToken.find_by(token: params[:token])
       return head :not_found unless share_token
-      stats = Liff::HistoryAggregator.new(share_token.user).call
+
+      data = Liff::HistoryAggregator.new(share_token.user).call
+      stats = data[:summary]
 
       png = Rails.cache.fetch("ogp_image/#{share_token.token}/#{Date.current}") do
         Ogp::ImageGenerator.new(stats).call


### PR DESCRIPTION
## 概要

OGPシェア画像で正答率・定着率の数値が表示されない不具合を修正しました。

## 問題

`/share/:token/og_image` でOGP画像を生成する際、`Liff::HistoryAggregator#call` の戻り値をそのまま `Ogp::ImageGenerator` に渡していたため、`summary` キー配下にある `accuracy_rate` / `mastery_rate` を取得できず、画像内のテキストが「正答率: %」のように数値部分が空欄になっていました。

## 原因

`Public::SharesController#show` では `data[:summary]` を取り出して `@stats` に渡しているのに対し、`#og_image` では `data` をネストしたまま `Ogp::ImageGenerator.new(stats)` に渡してしまっていました。

```ruby
# 修正前
data = Liff::HistoryAggregator.new(share_token.user).call
Ogp::ImageGenerator.new(data).call  # dataはネストした構造のまま

# 修正後
data = Liff::HistoryAggregator.new(share_token.user).call
stats = data[:summary]
Ogp::ImageGenerator.new(stats).call
```

## 修正内容

- `Public::SharesController#og_image` で `Liff::HistoryAggregator` の戻り値から `summary` を取り出すよう修正

## 動作確認

- [x] 本番環境のRailsコンソールで `ShareToken` のtokenを確認
- [x] シークレットブラウザで `og_image` のURLに直接アクセスし、画像が表示されることを確認
- [x] 修正前は正答率・定着率の数値が空欄になっていることを確認
- [x] 本番デプロイ後、`og_image` で正答率・定着率の数値が正しく表示されることを確認
- [x] `/share/:token` のページからシェアした際のプレビューを確認

## 関連Issue

(close #202)