### PR TITLE
AnswerRecorderのRSpecテストを追加

### DIFF
--- a/spec/factories/answer_factory.rb
+++ b/spec/factories/answer_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :answer do
+    association :user
+    association :question
+    answer_choice { 1 }
+    is_correct { true }
+    delivered_at { Time.current }
+    last_answered_at { Time.current }
+  end
+end

--- a/spec/factories/question_factory.rb
+++ b/spec/factories/question_factory.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :question do
+    sequence(:number) { |n| n }
+    content { "テスト問題文です。" }
+    image_url { nil }
+    choice_1 { "選択肢1" }
+    choice_2 { "選択肢2" }
+    choice_3 { "選択肢3" }
+    choice_4 { "選択肢4" }
+    correct_answer { "1" }
+    explanation_url { "https://example.com/explanation" }
+    year { 2023 }
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    sequence(:line_user_id) { |n| "test_line_user_id_#{n}" }
+    name { "テストユーザー" }
+    state { 0 }
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,4 +70,5 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include ActiveSupport::Testing::TimeHelpers
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/services/answer_recorder_spec.rb
+++ b/spec/services/answer_recorder_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe AnswerRecorder do
   describe '.call' do
-    let(:user){ create(:user) }
-    let(:question){ create(:question) }  
+    let(:user) { create(:user) }
+    let(:question) { create(:question) }
 
     subject(:call_recorder) do
       described_class.call(
@@ -15,8 +15,8 @@ RSpec.describe AnswerRecorder do
     end
 
     context '初めてその問題に回答する場合' do
-      let(:answer_choice){ 1 }
-      let(:is_correct){ true }
+      let(:answer_choice) { 1 }
+      let(:is_correct) { true }
 
       it '新しいAnswerレコードが1件作成される' do
         expect { call_recorder }.to change(Answer, :count).by(1)
@@ -27,7 +27,7 @@ RSpec.describe AnswerRecorder do
         expect(answer).to have_attributes(
           user_id: user.id,
           question_id: question.id,
-          answer_choice: 1, 
+          answer_choice: 1,
           is_correct: true
         )
       end
@@ -41,7 +41,7 @@ RSpec.describe AnswerRecorder do
     end
 
     context 'すでに回答したことがある問題に再回答する場合' do
-      let(:answer_choice){ 2 }
+      let(:answer_choice) { 2 }
       let(:is_correct) { false }
       let!(:existing_answer) do
         create(
@@ -75,7 +75,7 @@ RSpec.describe AnswerRecorder do
           expect(answer.last_answered_at).to eq(Time.current)
         end
       end
-      
+
       it '同じレコード(id)が使い回される' do
         answer = call_recorder
         expect(answer.id).to eq(existing_answer.id)
@@ -85,7 +85,7 @@ RSpec.describe AnswerRecorder do
     context '正解した場合' do
       let(:answer_choice) { 1 }
       let(:is_correct) { true }
- 
+
       it 'is_correctがtrueで保存される' do
         expect(call_recorder.is_correct).to eq(true)
       end
@@ -94,7 +94,7 @@ RSpec.describe AnswerRecorder do
     context '不正解だった場合' do
       let(:answer_choice) { 3 }
       let(:is_correct) { false }
- 
+
       it 'is_correctがfalseで保存される' do
         expect(call_recorder.is_correct).to eq(false)
       end
@@ -103,11 +103,11 @@ RSpec.describe AnswerRecorder do
     context '戻り値について' do
       let(:answer_choice) { 1 }
       let(:is_correct) { true }
- 
+
       it '保存されたAnswerのインスタンスを返す' do
         expect(call_recorder).to be_a(Answer)
       end
- 
+
       it '返されたAnswerは永続化済み(persisted)である' do
         expect(call_recorder).to be_persisted
       end

--- a/spec/services/answer_recorder_spec.rb
+++ b/spec/services/answer_recorder_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe AnswerRecorder do
+  describe '.call' do
+    let(:user){ create(:user) }
+    let(:question){ create(:question) }  
+
+    subject(:call_recorder) do
+      described_class.call(
+        user: user,
+        question: question,
+        answer_choice: answer_choice,
+        is_correct: is_correct
+      )
+    end
+
+    context '初めてその問題に回答する場合' do
+      let(:answer_choice){ 1 }
+      let(:is_correct){ true }
+
+      it '新しいAnswerレコードが1件作成される' do
+        expect { call_recorder }.to change(Answer, :count).by(1)
+      end
+
+      it '渡した属性が正しく保存される' do
+        answer = call_recorder
+        expect(answer).to have_attributes(
+          user_id: user.id,
+          question_id: question.id,
+          answer_choice: 1, 
+          is_correct: true
+        )
+      end
+
+      it 'delivered_atに現在時刻が設定される' do
+        freeze_time do
+          answer = call_recorder
+          expect(answer.delivered_at).to eq(Time.current)
+        end
+      end
+    end
+
+    context 'すでに回答したことがある問題に再回答する場合' do
+      let(:answer_choice){ 2 }
+      let(:is_correct) { false }
+      let!(:existing_answer) do
+        create(
+          :answer,
+          user: user,
+          question: question,
+          answer_choice: 1,
+          is_correct: true,
+          delivered_at: 3.days.ago,
+          last_answered_at: 3.days.ago
+        )
+      end
+
+      it '新しいレコードは作られず、既存レコードが更新される' do
+        expect { call_recorder }.not_to change(Answer, :count)
+      end
+
+      it 'answer_choiceとis_correctが最新の回答内容で上書きされる' do
+        answer = call_recorder
+        expect(answer).to have_attributes(answer_choice: 2, is_correct: false)
+      end
+
+      it 'delivered_atは最初に配信された時刻のまま変わらない' do
+        answer = call_recorder
+        expect(answer.delivered_at).to be_within(1.second).of(3.days.ago)
+      end
+
+      it 'last_answered_atは現在時刻に更新される' do
+        freeze_time do
+          answer = call_recorder
+          expect(answer.last_answered_at).to eq(Time.current)
+        end
+      end
+      
+      it '同じレコード(id)が使い回される' do
+        answer = call_recorder
+        expect(answer.id).to eq(existing_answer.id)
+      end
+    end
+
+    context '正解した場合' do
+      let(:answer_choice) { 1 }
+      let(:is_correct) { true }
+ 
+      it 'is_correctがtrueで保存される' do
+        expect(call_recorder.is_correct).to eq(true)
+      end
+    end
+
+    context '不正解だった場合' do
+      let(:answer_choice) { 3 }
+      let(:is_correct) { false }
+ 
+      it 'is_correctがfalseで保存される' do
+        expect(call_recorder.is_correct).to eq(false)
+      end
+    end
+
+    context '戻り値について' do
+      let(:answer_choice) { 1 }
+      let(:is_correct) { true }
+ 
+      it '保存されたAnswerのインスタンスを返す' do
+        expect(call_recorder).to be_a(Answer)
+      end
+ 
+      it '返されたAnswerは永続化済み(persisted)である' do
+        expect(call_recorder).to be_persisted
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
AnswerRecorder（回答記録サービスオブジェクト）に対するRSpecテストを追加しました。

## 変更内容
- `spec/services/answer_recorder_spec.rb` を追加
  - 初めて回答する場合：新規Answerレコードが作成されること、渡した属性が正しく保存されることを検証
  - 再回答する場合：既存レコードが更新されること、`delivered_at`（配信日時）は上書きされないことを検証
  - 正解/不正解それぞれのケースでの `is_correct` の保存を検証
  - 戻り値がAnswerインスタンスであり、永続化済みであることを検証
- FactoryBotを使えるように `spec/rails_helper.rb` に `config.include FactoryBot::Syntax::Methods` を追加
- `spec/factories/` に `user`, `question`, `answer` の各ファクトリを新規作成

## 動作確認
- `docker compose exec web bundle exec rspec spec/services/answer_recorder_spec.rb` で全件パス確認済み

## 関連Issue
Closes Issue #182