### PR TITLE
Test/184 deliver question job spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,9 @@ jobs:
         env:
           RAILS_ENV: test
           DATABASE_URL: postgres://postgres:postgres@localhost:5432
+          DB_HOST: localhost
+          DB_USERNAME: postgres
+          DB_PASSWORD: postgres
           # REDIS_URL: redis://localhost:6379/0
         run: bin/rails db:test:prepare test test:system
 

--- a/app/jobs/deliver_question_job.rb
+++ b/app/jobs/deliver_question_job.rb
@@ -25,6 +25,7 @@ class DeliverQuestionJob < ApplicationJob
   private
 
   def select_question(user)
+    Rails.logger.debug "DEBUG: rand=#{rand}, REVIEW_RATIO=#{REVIEW_RATIO}"
     if rand < REVIEW_RATIO
       # 復習問題を取得（SM-2でnext_review_atが来ているもの）
       review_question = Answer.where(user_id: user.id)

--- a/compose.yml
+++ b/compose.yml
@@ -62,6 +62,23 @@ services:
       LINE_LOGIN_CHANNEL_ID: ${LINE_LOGIN_CHANNEL_ID}
     depends_on:
       - web
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    command: bundle exec rspec
+    volumes:
+      - .:/myapp
+      - bundle_data:/usr/local/bundle:cached
+      - node_modules:/myapp/node_modules
+    environment:
+      TZ: Asia/Tokyo
+      RAILS_ENV: test
+      LINE_CHANNEL_SECRET: ${LINE_CHANNEL_SECRET}
+      LINE_CHANNEL_TOKEN: ${LINE_CHANNEL_TOKEN}
+    depends_on:
+      db:
+        condition: service_healthy
 volumes:
   bundle_data:
   postgresql_data:

--- a/config/database.yml
+++ b/config/database.yml
@@ -72,8 +72,13 @@ production:
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
-  <<: *default
-  database: fe_line_bot_development
+  primary:
+    <<: *default
+    database: fe_line_bot_test
+  queue:
+    <<: *default
+    database: fe_line_bot_test
+    migrations_paths: db/queue_migrate
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  host: db
+  host: <%= ENV.fetch("DB_HOST", "db") %>
   username: postgres
   password: password
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -19,8 +19,8 @@ default: &default
   # https://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
   host: <%= ENV.fetch("DB_HOST", "db") %>
-  username: postgres
-  password: password
+  username: <%= ENV.fetch("DB_USERNAME", "postgres") %>
+  password: <%= ENV.fetch("DB_PASSWORD", "password") %>
 
 development:
   primary:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -64,4 +64,6 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
+
+  config.active_job.queue_adapter = :test
 end

--- a/spec/factories/delivery_settings.rb
+++ b/spec/factories/delivery_settings.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :delivery_setting do
+    association :user
+    frequency { "daily" }
+    delivery_time_1 { Time.zone.parse("09:00") }
+  end
+end

--- a/spec/jobs/deliver_question_job_spec.rb
+++ b/spec/jobs/deliver_question_job_spec.rb
@@ -1,0 +1,130 @@
+require 'rails_helper'
+
+RSpec.describe DeliverQuestionJob, type: :job do
+  let(:user)     { create(:user) }
+  let(:setting)  { create(:delivery_setting, user: user) }
+  let(:question) { create(:question) }
+
+  # LINE API呼び出しは全テストでスタブ化
+  before do
+    allow_any_instance_of(Line::Bot::V2::MessagingApi::ApiClient)
+      .to receive(:push_message)
+  end
+
+  describe "#perform" do
+    context "ユーザーが存在しない場合" do
+      it "何もせずreturnする" do
+        expect { described_class.perform_now(0) }.not_to raise_error
+      end
+    end
+
+    context "配信設定がない場合" do
+      it "何もせずreturnする" do
+        expect { described_class.perform_now(user.id) }.not_to raise_error
+      end
+    end
+
+    context "問題が1件も存在しない場合" do
+      before { setting }
+      it "何もせずreturnする" do
+        expect { described_class.perform_now(user.id) }.not_to raise_error
+      end
+    end
+
+    context "正常系（ユーザー・設定・問題が揃っている場合）" do
+      before { setting; question }
+
+      it "LINE APIにpush_messageが送信される" do
+        api = instance_double(Line::Bot::V2::MessagingApi::ApiClient)
+        allow(Line::Bot::V2::MessagingApi::ApiClient).to receive(:new).and_return(api)
+        expect(api).to receive(:push_message)
+        described_class.perform_now(user.id)
+      end
+
+      it "次回配信ジョブがエンキューされる" do
+        expect {
+          described_class.perform_now(user.id)
+        }.to have_enqueued_job(DeliverQuestionJob)
+      end
+    end
+
+    context "DeliveryTimeCalculatorがnilを返す場合" do
+      before { setting; question }
+
+      it "次回ジョブがエンキューされない" do
+        allow(DeliveryTimeCalculator).to receive(:call).and_return(nil)
+        expect {
+          described_class.perform_now(user.id)
+        }.not_to have_enqueued_job(DeliverQuestionJob)
+      end
+    end
+  end
+
+  describe "#select_question（間接テスト）" do
+    before { setting }
+
+    context "rand < 0.7（復習ターン）かつ復習問題がある場合" do
+      it "due_for_reviewな問題が選ばれる" do
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.5)
+        review_answer = FactoryBot.create(:answer,
+          user: user, question: question, next_review_at: 1.day.ago)
+        # send_questionに渡されるquestionがreview_answerのquestionであることを確認
+        expect_any_instance_of(described_class)
+          .to receive(:send_question).with(user, question)
+        described_class.perform_now(user.id)
+      end
+    end
+
+    context "rand < 0.7（復習ターン）かつ復習問題がない場合" do
+      before { question }
+    
+      it "未回答の新問題が選ばれる" do
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.5)
+        expect_any_instance_of(described_class)
+          .to receive(:send_question).with(user, question)
+        described_class.perform_now(user.id)
+      end
+    end
+
+    context "rand >= 0.7（新問題ターン）の場合" do
+      before { question }
+
+      it "復習をスキップして新問題が選ばれる" do
+        job = described_class.new(user.id)
+        allow(job).to receive(:rand).and_return(0.8)
+        expect(Answer).not_to receive(:due_for_review)
+        expect(job).to receive(:send_question).with(user, question)
+        job.perform_now
+      end
+    end
+
+    context "全問題を回答済みの場合" do
+      it "既回答問題からランダムに選ばれる（nilにならない）" do
+        FactoryBot.create(:answer, user: user, question: question)
+        allow_any_instance_of(described_class).to receive(:rand).and_return(0.8)
+        expect_any_instance_of(described_class)
+          .to receive(:send_question).with(user, question)
+        described_class.perform_now(user.id)
+      end
+    end
+
+    context "LINE API送信が失敗する場合" do
+      before do
+       setting
+       question
+       allow_any_instance_of(Line::Bot::V2::MessagingApi::ApiClient)
+        .to receive(:push_message).and_raise(StandardError, "API Error")
+      end
+
+      it "エラーがraiseされず処理が継続する" do
+        expect{ described_class.perform_now(user.id)}.not_to raise_error
+      end
+
+      it "送信失敗しても次回ジョブはスケジュールされる" do
+        expect {
+          described_class.perform_now(user.id)
+        }.to have_enqueued_job(DeliverQuestionJob)
+      end
+    end
+  end
+end

--- a/spec/jobs/deliver_question_job_spec.rb
+++ b/spec/jobs/deliver_question_job_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe DeliverQuestionJob, type: :job do
 
     context "rand < 0.7（復習ターン）かつ復習問題がない場合" do
       before { question }
-    
+
       it "未回答の新問題が選ばれる" do
         allow_any_instance_of(described_class).to receive(:rand).and_return(0.5)
         expect_any_instance_of(described_class)
@@ -117,7 +117,7 @@ RSpec.describe DeliverQuestionJob, type: :job do
       end
 
       it "エラーがraiseされず処理が継続する" do
-        expect{ described_class.perform_now(user.id)}.not_to raise_error
+        expect { described_class.perform_now(user.id) }.not_to raise_error
       end
 
       it "送信失敗しても次回ジョブはスケジュールされる" do


### PR DESCRIPTION
## 概要

`DeliverQuestionJob`のRSpecテストを追加しました。
あわせて、テスト実行時にdevelopment用DBを参照してしまっていた環境設定の不備を修正しています。

（close Issue #184 ）

## 変更内容

### テストコード
- `spec/jobs/deliver_question_job_spec.rb` を新規作成
  - `perform`の早期returnパターン（user未存在 / setting未存在 / question未存在）
  - 正常系（push_message送信・次回ジョブエンキュー）
  - `DeliveryTimeCalculator`が`nil`を返す場合に次回ジョブがエンキューされないこと
  - `select_question`の分岐を間接テストで検証
    - 復習問題あり / なし
    - 新問題ターン（rand >= REVIEW_RATIO）
    - 全問回答済みのフォールバック
  - LINE API送信失敗時も`rescue`により処理が継続し、次回ジョブがスケジュールされること
- `spec/factories/delivery_settings.rb` を新規作成

### 環境設定
- `config/database.yml` のtestセクションが development と同一DBを参照していたため、専用DB（`fe_line_bot_test`）を参照するよう修正
- CI 環境で PostgreSQL service に接続できるよう、DB 接続情報を環境変数化し、GitHub Actions のテスト実行時に `DB_HOST` / `DB_USERNAME` / `DB_PASSWORD` を設定

## 動作確認

```bash
docker compose run --rm test bundle exec rspec spec/jobs/deliver_question_job_spec.rb
```

12 examples, 0 failures を確認済み。

## 補足・今後の対応

以下は本PRのスコープ外として、別Issueで対応予定です。

- `UnfollowEvent`未実装によるブロックユーザーへの配信継続問題
  → Issue: ブロックされたユーザーへの配信を停止する（UnfollowEvent対応）