### PR TITLE
test: ActiveJob::Base.queue_adapter を test に設定

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,7 +72,7 @@ RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
 
   config.include FactoryBot::Syntax::Methods
-  
+
   config.before(:suite) do
     ActiveJob::Base.queue_adapter = :test
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,5 +70,10 @@ RSpec.configure do |config|
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
   config.include ActiveSupport::Testing::TimeHelpers
+
   config.include FactoryBot::Syntax::Methods
+  
+  config.before(:suite) do
+    ActiveJob::Base.queue_adapter = :test
+  end
 end


### PR DESCRIPTION
## 原因
`config/environments/test.rb` には `config.active_job.queue_adapter = :test` が設定済みでしたが、`spec/rails_helper.rb` 側でも明示的に設定する必要があったため、`RSpec.configure` の `before(:suite)` フックで設定を追加しました。

## 変更内容
- `spec/rails_helper.rb` に以下を追加

```ruby
config.before(:suite) do
  ActiveJob::Base.queue_adapter = :test
end
```

## 影響範囲
- テスト環境（`RAILS_ENV=test`）にのみ影響する変更です。
- `spec/rails_helper.rb` はRSpec実行時にのみ読み込まれるため、本番・開発環境のジョブ実行（LINE通知配信など）には影響ありません。

## 動作確認
- [x] `docker compose run --rm test bundle exec rspec` で `deliver_question_job_spec.rb` の `have_enqueued_job` 系のテストが正しく動作することを確認
- [x] 既存のテストがすべてパスすることを確認

## 関連Issue
Closes #211 