### PR TITLE
fix: Request Specのパスをルーティングに合わせて修正

### DIFF
--- a/spec/requests/liff/settings_spec.rb
+++ b/spec/requests/liff/settings_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Liff::Settings", type: :request do
   describe "GET /index" do
     it "returns http success" do
-      get "/liff/settings/index"
+      get "/liff/settings"
       expect(response).to have_http_status(:success)
     end
   end


### PR DESCRIPTION
## 概要
- Request Specのリクエストパスを実際のルーティングに合わせて修正

## 変更内容
- `/liff/settings/index` を `/liff/settings` に修正

## 動作確認
- RSpecが正常に通ることを確認