### PR TITLE
chore: バリデーションエラーメッセージ等を日本語化

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,8 @@ gem "solid_queue"
 
 gem "mission_control-jobs"
 
+gem "rails-i18n"
+
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,6 +292,9 @@ GEM
     rails-html-sanitizer (1.7.0)
       loofah (~> 2.25)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.3)
       actionpack (= 7.2.3)
       activesupport (= 7.2.3)
@@ -454,6 +457,7 @@ DEPENDENCIES
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.3)
+  rails-i18n
   rspec-rails
   rubocop-rails-omakase
   sassc-rails
@@ -581,6 +585,7 @@ CHECKSUMS
   rails (7.2.3) sha256=9a9812eb131189676e64665f6883fc9c4051f412cc87ef9e3fa242a09c609bff
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
   rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-i18n (7.0.10) sha256=efae16e0ac28c0f42e98555c8db1327d69ab02058c8b535e0933cb106dd931ca
   railties (7.2.3) sha256=6eb010a6bfe6f223e783f739ddfcbdb5b88b1f3a87f7739f0a0685e466250422
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c

--- a/config/application.rb
+++ b/config/application.rb
@@ -24,5 +24,9 @@ module Newapp
     #
     config.time_zone = "Tokyo"
     config.eager_load_paths << Rails.root.join("extras")
+
+    # デフォルトロケールを日本語に設定
+    config.i18n.default_locale = :ja
+    config.i18n.available_locales = [ :ja, :en ]
   end
 end


### PR DESCRIPTION
## 概要
バリデーションエラーメッセージ等のデフォルト表示を日本語化しました。
(Close Issue #216 )

## 背景
ShareTokenモデルのテスト作成中、バリデーションエラーメッセージが
英語のデフォルト（can't be blank 等）のままであることに気づいたため対応。

## 変更内容
- Gemfile に `rails-i18n` を追加
- config/application.rb に以下を追加
  - `config.i18n.default_locale = :ja`
  - `config.i18n.available_locales = [:ja, :en]`

## 影響範囲の調査
導入前に以下を grep で確認し、既存コードへの影響がないことを確認済みです。