### PR TITLE
FollowEvent処理に例外ハンドリングを追加

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -27,19 +27,24 @@ class LineBotController < ApplicationController
     events.each do |event|
       case event
       when Line::Bot::V2::Webhook::FollowEvent
-        user = User.find_or_create_by(line_user_id: event.source.user_id)
-        is_new_user = user.delivery_setting.nil?
+        begin
+          user = User.find_or_create_by(line_user_id: event.source.user_id)
+          is_new_user = user.delivery_setting.nil?
 
-        # デフォルトの配信設定を作成（再登録時は既存設定を使う）
-        setting = user.delivery_setting || user.create_delivery_setting!(
-          frequency: "daily",
-          delivery_time_1: Time.zone.parse("09:00")
-        )
+          # デフォルトの配信設定を作成（再登録時は既存設定を使う）
+          setting = user.delivery_setting || user.create_delivery_setting!(
+            frequency: "daily",
+            delivery_time_1: Time.zone.parse("09:00")
+          )
 
-        # 初回配信ジョブを積む（新規ユーザーのみ。再フォロー時は既にジョブが動いているため、二重に積まないようにする）
-        if is_new_user
-          first_delivery = DeliveryTimeCalculator.call(setting)
-          DeliverQuestionJob.set(wait_until: first_delivery).perform_later(user.id) if first_delivery
+          # 初回配信ジョブを積む（新規ユーザーのみ。再フォロー時は既にジョブが動いているため、二重に積まないようにする）
+          if is_new_user
+            first_delivery = DeliveryTimeCalculator.call(setting)
+            DeliverQuestionJob.set(wait_until: first_delivery).perform_later(user.id) if first_delivery
+          end
+        rescue => e
+          Rails.logger.error "FollowEvent processing error: #{e.class} #{e.message} line_user_id=#{event.source.user_id}"
+          Rails.logger.error e.backtrace.join("\n")
         end
 
       when Line::Bot::V2::Webhook::MessageEvent


### PR DESCRIPTION
## 概要
FollowEvent受信時の処理(delivery_setting作成、初回配信ジョブのセット)を \`begin/rescue\` で囲み、例外発生時にループ全体が停止しないようにした。

## 背景
本番DBを確認したところ、実際に友だち追加された5名のユーザーで \`delivery_setting\` が作成されていないことが判明。原因は特定できなかったが（Renderのログ保持期間が短く過去ログが確認できず）、\`FollowEvent\` の処理に例外ハンドリングが存在せず、エラーが発生した場合に気づけない構造になっていた。

## 変更内容
- \`FollowEvent\` の処理全体を \`begin/rescue\` で囲む
- \`rescue\` 節でエラークラス・メッセージ・\`line_user_id\` をログ出力し、原因調査をしやすくする
- 既存の \`handle_message\` メソッドと同様のエラーハンドリングパターンに統一

## 影響範囲
- \`LineBotController#callback\` の \`FollowEvent\` 分岐のみ
- 既存の正常系の挙動に変更なし

## 動作確認
- [ ] 手元でLIFF/Bot経由のフォロー動作を確認
- [ ] CI通過確認"