### PR TITLE
本番環境のconfig.hostsに独自ドメインを追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,10 +100,10 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = [ :id ]
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts << "fetokku.com"
+  config.hosts << "www.fetokku.com"
+  config.hosts << "fe-line-bot.onrender.com"
+
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
 end


### PR DESCRIPTION
## 概要
独自ドメイン（fetokku.com / www.fetokku.com）取得に伴い、Rails 7の Host Authorization 機能に対応するため \`config.hosts\` へ許可ドメインを追加した。

## 変更内容
- \`config.hosts\` に \`fetokku.com\`、\`www.fetokku.com\`、\`fe-line-bot.onrender.com\`（Render提供の旧URL）を追加
- ヘルスチェック用エンドポイント（\`/up\`）がHost Authorizationで弾かれないよう、\`config.host_authorization\` の除外設定を有効化

## 影響範囲
- \`config/environments/production.rb\` のみ
- 本番環境の起動・ルーティング挙動に影響するため、デプロイ後に実際のアクセス確認が必要

## 動作確認
- [x] デプロイ後、独自ドメイン（https://fetokku.com、https://www.fetokku.com）でアクセスできることを確認
- [x] Render提供URL（https://fe-line-bot.onrender.com）でも引き続きアクセスできることを確認
- [x] CI通過確認