### PR TITLE
開発環境でSolid Queueワーカーが二重起動する問題を修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -41,27 +41,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
-  worker:
-    build:
-      context: .
-      dockerfile: Dockerfile.dev
-    command: bundle exec rails solid_queue:start
-    volumes:
-      - .:/myapp
-      - bundle_data:/usr/local/bundle:cached
-    environment:
-      TZ: Asia/Tokyo
-      LINE_CHANNEL_SECRET: ${LINE_CHANNEL_SECRET}
-      LINE_CHANNEL_TOKEN: ${LINE_CHANNEL_TOKEN}
-      RAILS_LOG_TO_STDOUT: "true"
-      RAILS_ENV: development
-      ADMIN_USER: admin
-      ADMIN_PASSWORD: 1234
-      LIFF_ID_SETTINGS: ${LIFF_ID_SETTINGS} 
-      LIFF_ID_HISTORY: ${LIFF_ID_HISTORY} 
-      LINE_LOGIN_CHANNEL_ID: ${LINE_LOGIN_CHANNEL_ID}
-    depends_on:
-      - web
   test:
     build:
       context: .


### PR DESCRIPTION
Closes #227

## 概要
docker-compose.yml に、web サービス内(Procfile.dev)と独立した
worker サービスの両方でSolid Queueが起動しており、
開発環境でワーカーが二重起動していた。

## 対応内容
docker-compose.yml から独立した worker サービスを削除し、
web サービス内の Procfile.dev 経由のワーカーのみに一本化した。

## 確認事項・懸念点
- 独立した worker コンテナが起動しなくなったことは確認済み
- web コンテナ内(Procfile.dev経由)のワーカーが正常に稼働しているかは、
  docker compose up 経由だと起動ログ(Started Worker)が確認できておらず、
  追加の検証が必要
  （bundle exec rails solid_queue:start を直接実行した場合は正常起動を確認済み）

## 今後の対応
上記の懸念点について、別途動作検証を行う