### PR TITLE
Dependabotのtarget-branchをdevelopに変更 (#231)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,13 @@ version: 2
 updates:
 - package-ecosystem: bundler
   directory: "/"
+  target-branch: develop
   schedule:
     interval: daily
   open-pull-requests-limit: 10
 - package-ecosystem: github-actions
   directory: "/"
+  target-branch: develop
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
## 概要
Dependabotが作成するPRのbase branchがデフォルトで `main` になっており、
本プロジェクトの `develop` ブランチ運用と合っていなかったため、
`.github/dependabot.yml` に `target-branch: develop` を追加しました。

Closes #231 

## 背景
- 講師のフィードバックを受けて develop ブランチを起点とした運用に切り替えている
- 一方 Dependabot は特に設定しない限りリポジトリのデフォルトブランチ(main)向けにPRを作成するため、既存の運用と矛盾していたため
- 現在Open中のDependabot PR(11件)もすべて main 向けに作成されていることを確認済み

## 変更内容
- `bundler` / `github-actions` 両方の updates 設定に `target-branch: develop` を追加
- これにより、今後Dependabotが作成するPRは自動的に develop 向けになる

## 影響範囲・注意点
- セキュリティアラートによる緊急PRには target-branch が適用されない場合があるとの情報があるため、その場合は個別に対応する

## 動作確認
- [ ] マージ後、次回のDependabot実行(daily)でPRが develop 向けに作成されることを確認する