### PR TITLE
.env.sample作成とLIFF_CHANNEL_ID未設定の修正

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,11 @@
+# ===== LINE Messaging API =====
+LINE_CHANNEL_SECRET=
+LINE_CHANNEL_TOKEN=
+
+# ===== LIFF =====
+# LINE Developers ConsoleのLIFFタブで確認できるChannel ID
+LIFF_CHANNEL_ID=
+# 学習履歴画面用LIFF ID
+LIFF_ID_HISTORY=
+# 配信設定画面用LIFF ID
+LIFF_ID_SETTINGS=

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+!/.env.sample
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     - [【コア技術】LINE Messaging API / LIFF](#コア技術line-messaging-api--liff)
     - [【デプロイ先】Render](#デプロイ先render)
   - [開発環境構築方法](#開発環境構築方法)
+    - [環境変数の設定](#環境変数の設定)
     - [スマートフォンからローカル環境を確認する場合](#スマートフォンからローカル環境を確認する場合)
     - [データベースのリセット](#データベースのリセット)
   - [工夫したポイント](#工夫したポイント)
@@ -145,6 +146,21 @@ css:    SCSSのビルド・監視（yarn watch:css）
 worker: Solid Queueワーカー
 ```
 
+### 環境変数の設定
+
+`.env.sample` をコピーして `.env` を作成し、各値を設定してください。
+
+\`\`\`bash
+cp .env.sample .env
+\`\`\`
+
+| 変数名 | 取得方法 |
+| --- | --- |
+| `LINE_CHANNEL_SECRET` / `LINE_CHANNEL_TOKEN` | LINE Developers Console の Messaging APIチャネル |
+| `LIFF_CHANNEL_ID` | LINE Developers Console の LIFFタブ |
+| `LIFF_ID_HISTORY` / `LIFF_ID_SETTINGS` | 同上（学習履歴用・配信設定用それぞれのLIFF ID） |
+
+
 ### スマートフォンからローカル環境を確認する場合
 
 同一Wi-Fi内の実機からローカルサーバーへアクセスしたい場合、WSL2環境ではWindows側でのポート転送（`netsh interface portproxy`）とRailsの`config.hosts`設定が別途必要です。
@@ -219,11 +235,15 @@ LIFF画面でユーザーを識別する際、フロントエンドから送ら�
 ```ruby
 # Faradayを使ってLINEのverify APIにIDTokenを送信し、検証済みのline_user_idのみを信頼する
 response = Faraday.post("https://api.line.me/oauth2/v2.1/verify") do |req|
-  req.body = { id_token: id_token, client_id: ENV["LINE_LOGIN_CHANNEL_ID"] }
+  req.headers["Content-Type"] = "application/x-www-form-urlencoded"
+  req.body = URI.encode_www_form(
+    id_token: id_token,
+    client_id: ENV.fetch("LIFF_CHANNEL_ID")
+  )
 end
 
-verified_line_user_id = JSON.parse(response.body)["sub"]
-session[:line_user_id] = verified_line_user_id
+result = JSON.parse(response.body)
+session[:line_user_id] = result["sub"]
 ```
 
 クライアントから送られた値を無条件に信頼しない、という基本方針を個人開発でも徹底した点を意識しました。

--- a/compose.yml
+++ b/compose.yml
@@ -33,9 +33,9 @@ services:
       RAILS_ENV: development
       ADMIN_USER: admin
       ADMIN_PASSWORD: 1234
+      LIFF_CHANNEL_ID: ${LIFF_CHANNEL_ID} 
       LIFF_ID_SETTINGS: ${LIFF_ID_SETTINGS} 
       LIFF_ID_HISTORY: ${LIFF_ID_HISTORY} 
-      LINE_LOGIN_CHANNEL_ID: ${LINE_LOGIN_CHANNEL_ID}
     ports:
       - "3000:3000"
     depends_on:
@@ -53,6 +53,7 @@ services:
     environment:
       TZ: Asia/Tokyo
       RAILS_ENV: test
+      LIFF_CHANNEL_ID: ${LIFF_CHANNEL_ID} 
       LINE_CHANNEL_SECRET: ${LINE_CHANNEL_SECRET}
       LINE_CHANNEL_TOKEN: ${LINE_CHANNEL_TOKEN}
     depends_on:


### PR DESCRIPTION
## 概要
close #250

ローカル(Docker)環境で学習履歴・配信設定のLIFF画面が開けない不具合を調査し、原因を修正しました。
あわせて`.env.sample`を整備しました。

## 原因
`compose.yml`の`web`/`test`サービスに`LIFF_CHANNEL_ID`が渡っておらず、`Liff::SessionsController#create`内の`ENV.fetch("LIFF_CHANNEL_ID")`がKeyErrorを起こしていました。未使用の`LINE_LOGIN_CHANNEL_ID`という変数名が代わりに定義されており、実装時の変数名の付け間違い・移行漏れが原因と考えられます。

## 変更内容
- `compose.yml`: `web`/`test`サービスに`LIFF_CHANNEL_ID`を追加、未使用の`LINE_LOGIN_CHANNEL_ID`を削除
- `.env.sample`を新規作成（LINE Messaging API / LIFF関連の必須環境変数を明記）
- README
  - 「開発環境構築方法」に「環境変数の設定」セクションを追加
  - 「工夫したポイント」のLINE IDToken検証のコードスニペットを、実装（`URI.encode_www_form`, `ENV.fetch("LIFF_CHANNEL_ID")`）に合わせて修正

## 動作確認
- [x] ローカル(Docker + ngrok)で学習履歴画面が正常に開けることを確認
- [x] SNS共有（OGP画像生成含む）が200 OKで動作することを確認
- [ ] `.env.sample`から`.env`を新規作成した状態でセットアップできることを確認（レビュー時に確認予定）

## 補足
本番環境ではこの問題は発生していません（Render側の環境変数は正しく設定済みのため）。