### PR TITLE
fix: Public::Sharesでallow_browserを無効化し403エラーを解消 (#issue257)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.24.6)
       msgpack (~> 1.2)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     capybara (3.40.0)
@@ -491,7 +491,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.24.6) sha256=c60bab88c70332290f0a2636a288f675299eb4f804a02a3c085b42eca9da164a
-  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   cgi (0.5.2) sha256=61ca30298171190fd4fa0d8018e57ada456eae9b7a2b78526debf7f0a0e6f8bb

--- a/app/controllers/public/shares_controller.rb
+++ b/app/controllers/public/shares_controller.rb
@@ -1,10 +1,10 @@
 module Public
   class SharesController < ApplicationController
     layout "public" # liff.js を読み込まない専用レイアウト
-    
+
     # クローラー(LINE/Twitter等のOGPボット)や旧ブラウザからのアクセスも許可する必要があるため無効化
     allow_browser versions: :modern, block: false
-    
+
     def show
       @share_token = ShareToken.find_by(token: params[:token])
 

--- a/app/controllers/public/shares_controller.rb
+++ b/app/controllers/public/shares_controller.rb
@@ -1,7 +1,10 @@
 module Public
   class SharesController < ApplicationController
     layout "public" # liff.js を読み込まない専用レイアウト
-
+    
+    # クローラー(LINE/Twitter等のOGPボット)や旧ブラウザからのアクセスも許可する必要があるため無効化
+    allow_browser versions: :modern, block: false
+    
     def show
       @share_token = ShareToken.find_by(token: params[:token])
 


### PR DESCRIPTION
## 概要
`Public::SharesController`配下の`show`・`og_image`アクションが、期待するステータス（200/404/410）ではなく常に403 Forbiddenを返していた。

## 原因
`ApplicationController`にかけている`allow_browser versions: :modern`が、`Public::SharesController`にも継承されていた。
このコントローラは以下のように「モダンブラウザ」以外のUser-Agentからのアクセスも許可する必要がある。

- RSpecのリクエストスペック（デフォルトUser-Agentがモダンブラウザ判定を通らない）
- `og_image`アクションにアクセスするX等のOGPクローラー（本番でシェアプレビューが表示されない実害あり）

## 対応
`Public::SharesController`で`allow_browser`のチェックを無効化。

```ruby
allow_browser versions: :modern, block: false
```

## 動作確認
```bash
docker compose run --rm test bundle exec rspec spec/requests/public/shares_controller_spec.rb
```
6 examples, 0 failures

Closes #257