### PR TITLE
fix: db/seeds.rbにtest環境ガードを追加しテストDB汚染を防止 (#issue261)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,29 +1,33 @@
-require 'csv'
+if Rails.env.test?
+  Rails.logger.info "test環境では過去問CSVのseedをスキップします"
+else
+  require 'csv'
 
-Dir[Rails.root.join('db/csv/*.csv')].each do |file|
-  url_path = File.basename(file, '.csv')
-  Rails.logger.info "Importing #{url_path}..."
+  Dir[Rails.root.join('db/csv/*.csv')].each do |file|
+    url_path = File.basename(file, '.csv')
+    Rails.logger.info "Importing #{url_path}..."
 
-  reiwa_number = url_path[/\A\d+/].to_i
-  year = 2018 + reiwa_number # 令和N年 = 2018 + N
+    reiwa_number = url_path[/\A\d+/].to_i
+    year = 2018 + reiwa_number # 令和N年 = 2018 + N
 
-  CSV.foreach(file, headers: true, encoding: 'BOM|UTF-8') do |row|
-    number = row['number'].to_i
+    CSV.foreach(file, headers: true, encoding: 'BOM|UTF-8') do |row|
+      number = row['number'].to_i
 
-    Question.find_or_initialize_by(number: number).tap do |q|
-      q.content         = row['content']
-      q.correct_answer  = row['correct_answer']
-      q.image_url       = row['image_url'].presence
-      q.choice_1        = row['choice_1']
-      q.choice_2        = row['choice_2']
-      q.choice_3        = row['choice_3']
-      q.choice_4        = row['choice_4']
-      q.year            = year
-      q.explanation_url = row['explanation_url'].presence&.strip ||
-        "https://www.fe-siken.com/kakomon/#{url_path}/q#{number}.html"
-      q.save!
+      Question.find_or_initialize_by(number: number).tap do |q|
+        q.content         = row['content']
+        q.correct_answer  = row['correct_answer']
+        q.image_url       = row['image_url'].presence
+        q.choice_1        = row['choice_1']
+        q.choice_2        = row['choice_2']
+        q.choice_3        = row['choice_3']
+        q.choice_4        = row['choice_4']
+        q.year            = year
+        q.explanation_url = row['explanation_url'].presence&.strip ||
+          "https://www.fe-siken.com/kakomon/#{url_path}/q#{number}.html"
+        q.save!
+      end
     end
-  end
 
-  puts "#{url_path}: インポート完了（year=#{year}, 合計 #{Question.count} 件）"
+    puts "#{url_path}: インポート完了（year=#{year}, 合計 #{Question.count} 件）"
+  end
 end


### PR DESCRIPTION
## 概要
`DeliverQuestionJob#select_question`のテストが、テストで作成していないQuestionデータ（本物の過去問CSV由来）を選択してしまい断続的に失敗する問題を修正した。

## 原因
`db/seeds.rb`が環境を問わず`db/csv/*.csv`（本物の過去問データ）を無条件でQuestionテーブルにインポートする実装になっていた。`rails db:prepare`は「データベースが新規作成されたときにseedを読み込む」仕様のため、過去に何らかの理由で`RAILS_ENV=test`に対して`db:prepare`または`db:seed`が実行され、本物データがtest DBに混入したと考えられる。

## 対応
`db/seeds.rb`にtest環境向けのガードを追加し、test環境ではCSVインポートが走らないようにした。

## 動作確認
```bash
docker compose run --rm test bin/rails db:test:prepare
docker compose run --rm test bundle exec rspec
```

Closes #261 